### PR TITLE
Riccati Equation Solver

### DIFF
--- a/hipparchus-core/src/main/java/org/hipparchus/complex/ComplexComparator.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/complex/ComplexComparator.java
@@ -1,8 +1,8 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Hipparchus project under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
+ * The Hipparchus project licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *

--- a/hipparchus-core/src/main/java/org/hipparchus/complex/ComplexComparator.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/complex/ComplexComparator.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hipparchus.complex;
+
+import java.util.Comparator;
+
+/**
+ * Comparator for Complex Numbers.
+ * 
+ */
+public class ComplexComparator implements Comparator<Complex> {
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
+	 */
+	public int compare(Complex o1, Complex o2) {
+		if (o1 == null && o2 != null) {
+			return -1;
+		} else if (o1 != null && o2 == null) {
+			return 1;
+		} else if (o1 == null && o2 == null) {
+			return 0;
+		}
+
+		if (o1.getReal() < o2.getReal()) {
+			return -1;
+		} else {
+			if (o1.getReal() == o2.getReal()) {
+				if (o1.getImaginary() == o2.getImaginary()) {
+					return 0;
+				} else if (o1.getImaginary() < o2.getImaginary()) {
+					return -1;
+				} else {
+					return 1;
+				}
+			} else {
+				return 1;
+			}
+		}
+	}
+
+}

--- a/hipparchus-core/src/main/java/org/hipparchus/linear/Array2DRowRealMatrix.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/Array2DRowRealMatrix.java
@@ -28,6 +28,7 @@ import org.hipparchus.exception.LocalizedCoreFormats;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.MathIllegalStateException;
 import org.hipparchus.exception.NullArgumentException;
+import org.hipparchus.util.FastMath;
 import org.hipparchus.util.MathUtils;
 
 /**
@@ -590,5 +591,86 @@ public class Array2DRowRealMatrix extends AbstractRealMatrix implements Serializ
         }
         System.arraycopy(array, 0, data[row], 0, nCols);
     }
+
+	/**
+	 * Kronecker product of the current matrix and the parameter matrix.
+	 * 
+	 * @param b
+	 * @return
+	 */
+	public RealMatrix kroneckerProduct(final RealMatrix b) {
+		final int m = getRowDimension();
+		final int n = getColumnDimension();
+
+		final int p = b.getRowDimension();
+		final int q = b.getColumnDimension();
+
+		final RealMatrix kroneckerProduct = MatrixUtils.createRealMatrix(m * p,
+				n * q);
+
+		for (int i = 0; i < m; i++) {
+			for (int j = 0; j < n; j++) {
+				kroneckerProduct.setSubMatrix(b.scalarMultiply(getEntry(i, j))
+						.getData(), i * p, j * q);
+			}
+
+		}
+
+		return kroneckerProduct;
+	}
+
+	/**
+	 * Transforms a matrix in a vector (Vectorization).
+	 * 
+	 * @param b
+	 * @return
+	 */
+	public RealMatrix stack() {
+		final int m = getRowDimension();
+		final int n = getColumnDimension();
+
+		final RealMatrix stacked = MatrixUtils.createRealMatrix(m * n, 1);
+
+		for (int i = 0; i < m; i++) {
+			stacked.setSubMatrix(getColumnMatrix(i).getData(), i * n, 0);
+
+		}
+
+		return stacked;
+	}
+
+	/**
+	 * Transforms a vector in a squared matrix (devectorization).
+	 * 
+	 * @param b
+	 * @return
+	 */
+	public RealMatrix unstackSquare() {
+		final int m = getRowDimension();
+		final int n = getColumnDimension();
+		final double n_ = FastMath.sqrt(m);
+
+		if (n != 1) {
+			throw new MathIllegalArgumentException(
+					LocalizedCoreFormats.CONSTRAINT,
+					"Unstack works with arrays with column dimension 1");
+		}
+		if (n_ % 1 > 0) {
+			throw new MathIllegalArgumentException(
+					LocalizedCoreFormats.CONSTRAINT,
+					"Unstack works with arrays with row dimension defined by a square");
+		}
+		final int n__ = ((int) n_);
+
+		final RealMatrix unstacked = MatrixUtils.createRealMatrix(n__, n__);
+
+		for (int i = 0; i < n__; i++) {
+			unstacked.setColumnMatrix(i,
+					getSubMatrix(i * n__, i * n__ + n__ - 1, 0, 0));
+
+		}
+
+		return unstacked;
+	}
 
 }

--- a/hipparchus-core/src/main/java/org/hipparchus/linear/ComplexEigenDecomposition.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/ComplexEigenDecomposition.java
@@ -1,0 +1,335 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hipparchus.linear;
+
+import org.hipparchus.complex.Complex;
+import org.hipparchus.complex.ComplexField;
+import org.hipparchus.exception.LocalizedCoreFormats;
+import org.hipparchus.exception.MathIllegalArgumentException;
+import org.hipparchus.exception.MathRuntimeException;
+import org.hipparchus.util.FastMath;
+import org.hipparchus.util.Precision;
+
+/**
+ * Given a matrix A, it computes a complex eigen decomposition A = VDV^{T}. It
+ * checks the definition in runtime using AV = VD.
+ * 
+ * Complex Eigen Decomposition, it differs from the EigenDecomposition since it
+ * computes the eigen vectors as complex eigen vectors (if applicable).
+ * 
+ * Compute complex eigen values from the schur transform. Compute complex eigen
+ * vectors based on eigen values and the inverse iteration method.
+ * 
+ * see: https://en.wikipedia.org/wiki/Inverse_iteration
+ * https://en.wikiversity.org/wiki/Shifted_inverse_iteration
+ * http://www.robots.ox.ac.uk/~sjrob/Teaching/EngComp/ecl4.pdf
+ * http://www.math.ohiou.edu/courses/math3600/lecture16.pdf
+ * 
+ */
+public class ComplexEigenDecomposition {
+
+	/** Internally used epsilon criteria. */
+	private static final double EPSILON = 1e-12;
+	/** complex eigenvalues. */
+	private Complex[] eigenvalues;
+
+	/** Eigenvectors. */
+	private ArrayFieldVector<Complex>[] eigenvectors;
+	/** Cached value of V. */
+	private FieldMatrix<Complex> V;
+	/** Cached value of D. */
+	private FieldMatrix<Complex> D;
+
+	/**
+	 * Constructor for decomposition.
+	 * 
+	 * @param matrix
+	 *            real matrix.
+	 */
+	public ComplexEigenDecomposition(final RealMatrix matrix) {
+
+		if (!matrix.isSquare()) {
+			throw new MathIllegalArgumentException(
+					LocalizedCoreFormats.CONSTRAINT,
+					"The matrix must be a square matrix");
+		}
+
+		// computing the eigen values
+		findEigenValues(matrix);
+		// computing the eigen vectors
+		findEigenVectors(convertToFieldComplex(matrix));
+
+		// V
+		final int m = eigenvectors.length;
+		V = MatrixUtils.createFieldMatrix(ComplexField.getInstance(), m, m);
+		for (int k = 0; k < m; ++k) {
+			V.setColumnVector(k, eigenvectors[k]);
+		}
+
+		// D
+		D = MatrixUtils.createFieldDiagonalMatrix(eigenvalues);
+
+		checkDefinition(matrix);
+	}
+
+	/**
+	 * Getter of the eigen values.
+	 * 
+	 * @return igen values.
+	 */
+	public Complex[] getEigenvalues() {
+		return eigenvalues;
+	}
+
+	/**
+	 * Getter of the eigen vectors.
+	 * 
+	 * @param i
+	 *            which eigen vector.
+	 * @return eigen vector.
+	 */
+	public FieldVector<Complex> getEigenvector(final int i) {
+		return eigenvectors[i].copy();
+	}
+
+	/**
+	 * Confirm if there are complex eigen values.
+	 * 
+	 * @return true if there are complex eigen values.
+	 */
+	public boolean hasComplexEigenvalues() {
+		for (int i = 0; i < eigenvalues.length; i++) {
+			if (!Precision.equals(eigenvalues[i].getImaginary(), 0.0, EPSILON)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Computes the determinant.
+	 * 
+	 * @return the determinant.
+	 */
+	public double getDeterminant() {
+		Complex determinant = new Complex(1, 0);
+		for (Complex lambda : eigenvalues) {
+			determinant = determinant.multiply(lambda);
+		}
+		return determinant.getReal();
+	}
+
+	/**
+	 * Getter V.
+	 * 
+	 * @return V.
+	 */
+	public FieldMatrix<Complex> getV() {
+		return V;
+	}
+
+	/**
+	 * Getter D.
+	 * 
+	 * @return D.
+	 */
+	public FieldMatrix<Complex> getD() {
+		return D;
+	}
+
+	/**
+	 * Getter VT.
+	 * 
+	 * @return VT.
+	 */
+	public FieldMatrix<Complex> getVT() {
+		return V.transpose();
+	}
+
+	/**
+	 * Compute eigen values using the Schur transform.
+	 * 
+	 * @param matrix
+	 *            real matrix to compute eigen values.
+	 */
+	protected void findEigenValues(final RealMatrix matrix) {
+		final SchurTransformer schurTransform = new SchurTransformer(matrix);
+		final double[][] matT = schurTransform.getT().getData();
+
+		eigenvalues = new Complex[matT.length];
+
+		for (int i = 0; i < eigenvalues.length; i++) {
+			if (i == (eigenvalues.length - 1)
+					|| Precision.equals(matT[i + 1][i], 0.0, EPSILON)) {
+				eigenvalues[i] = new Complex(matT[i][i]);
+			} else {
+				final double x = matT[i + 1][i + 1];
+				final double p = 0.5 * (matT[i][i] - x);
+				final double z = FastMath.sqrt(FastMath.abs(p * p
+						+ matT[i + 1][i] * matT[i][i + 1]));
+				eigenvalues[i] = new Complex(x + p, z);
+				eigenvalues[i + 1] = new Complex(x + p, -z);
+				i++;
+			}
+		}
+
+	}
+
+	/**
+	 * Compute the eigen vectors using the inverse power method.
+	 * 
+	 * @param matrix
+	 *            real matrix to compute eigen vectors.
+	 */
+	@SuppressWarnings("unchecked")
+	protected void findEigenVectors(final FieldMatrix<Complex> matrix) {
+		// number of eigen values/vectors
+		int n = eigenvalues.length;
+
+		// identity
+		final FieldMatrix<Complex> ident = MatrixUtils
+				.createFieldIdentityMatrix(ComplexField.getInstance(), n);
+
+		// eigen vectors
+		eigenvectors = (ArrayFieldVector<Complex>[]) new ArrayFieldVector[n];
+
+		// computing eigen vector based on eigen values and inverse iteration
+		for (int i = 0; i < eigenvalues.length; i++) {
+			Complex eigenValue = eigenvalues[i];
+
+			// mu multiplied by Identity
+			// muI
+			FieldMatrix<Complex> eigv = ident.scalarMultiply(eigenValue
+					.add(EPSILON));
+
+			// A-muI
+			FieldMatrix<Complex> Aeigv = (FieldMatrix<Complex>) matrix
+					.subtract(eigv);
+
+			// finding inverse of (A - muI)
+			// (A - muI) (A - muI)^{-1} = I
+			FieldLUDecomposition<Complex> luDecomp = new FieldLUDecomposition<Complex>(
+					Aeigv);
+			FieldMatrix<Complex> inv_Aeigv = luDecomp.getSolver().getInverse();
+
+			// starting with a unitary vector
+			Complex[] unityVector = new Complex[n];
+			for (int k = 0; k < n; k++) {
+				unityVector[k] = new Complex(1, 0);
+			}
+			FieldVector<Complex> eigenVector = MatrixUtils
+					.createFieldVector(unityVector);
+
+			for (int k = 0; k < 2; k++) {
+				FieldVector<Complex> eigenVector_new = inv_Aeigv
+						.operate(eigenVector);
+				// normalizing
+				Complex norm = getNormInf(eigenVector_new);
+				eigenVector = eigenVector_new.mapDivide(norm);
+			}
+
+			eigenVector = eigenVector.mapAdd(Complex.ZERO);
+
+			eigenvectors[i] = new ArrayFieldVector<Complex>(
+					eigenVector.toArray());
+		}
+	}
+
+	/**
+	 * Compute the infinity norm of the a given vector.
+	 * 
+	 * @param vector
+	 *            vector.
+	 * @return infinity norm.
+	 */
+	private Complex getNormInf(FieldVector<Complex> vector) {
+		Complex norm = null;
+		for (int i = 0; i < vector.getDimension(); i++) {
+			if (norm == null) {
+				norm = vector.getEntry(i);
+			} else if (norm.abs() < vector.getEntry(i).abs()) {
+				norm = vector.getEntry(i);
+			}
+		}
+		return norm;
+	}
+
+	/**
+	 * Check definition of the decomposition in runtime.
+	 * 
+	 * @param matrix
+	 *            matrix to be decomposed.
+	 */
+	protected void checkDefinition(final RealMatrix matrix) {
+		FieldMatrix<Complex> matrixC = convertToFieldComplex(matrix);
+
+		// checking definition of the decomposition
+		// testing A*V = V*D
+		FieldMatrix<Complex> AV = matrixC.multiply(getV());
+		FieldMatrix<Complex> VD = getV().multiply(getD());
+		if (!equalsWithPrecision(AV, VD, EPSILON)) {
+			throw new MathRuntimeException(LocalizedCoreFormats.CONSTRAINT,
+					"Erro checking definition "
+							+ matrixC.multiply(getV()).toString() + " "
+							+ getV().multiply(getD()).toString());
+
+		}
+
+	}
+
+	/**
+	 * Helper method that checks with two matrix is equals taking into account a
+	 * given precision.
+	 * 
+	 * @param matrix
+	 * @return
+	 */
+	private boolean equalsWithPrecision(final FieldMatrix<Complex> matrix1,
+			final FieldMatrix<Complex> matrix2, final Double error) {
+		boolean toRet = true;
+		for (int i = 0; i < matrix1.getRowDimension(); i++) {
+			for (int j = 0; j < matrix1.getColumnDimension(); j++) {
+				Complex c1 = matrix1.getEntry(i, j);
+				Complex c2 = matrix2.getEntry(i, j);
+				if (c1.add(c2.negate()).abs() > error) {
+					toRet = false;
+					break;
+				}
+			}
+		}
+		return toRet;
+	}
+
+	/**
+	 * It converts a real matrix into a complex field matrix.
+	 * 
+	 * @param matrix
+	 *            real matrix.
+	 * @return complex matrix.
+	 */
+	private FieldMatrix<Complex> convertToFieldComplex(RealMatrix matrix) {
+		final FieldMatrix<Complex> toRet = MatrixUtils
+				.createFieldIdentityMatrix(ComplexField.getInstance(),
+						matrix.getRowDimension());
+		for (int i = 0; i < toRet.getRowDimension(); i++) {
+			for (int j = 0; j < toRet.getColumnDimension(); j++) {
+				toRet.setEntry(i, j, new Complex(matrix.getEntry(i, j)));
+			}
+		}
+		return toRet;
+	}
+}

--- a/hipparchus-core/src/main/java/org/hipparchus/linear/ComplexEigenDecomposition.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/ComplexEigenDecomposition.java
@@ -1,8 +1,8 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Hipparchus project under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
+ * The Hipparchus project licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
@@ -44,9 +44,10 @@ public class ComplexEigenDecomposition {
 
 	/** Internally used epsilon criteria. */
 	private static final double EPSILON = 1e-12;
+	/** Internally used epsilon criteria for equals. */
+	private static final double EPSILON_EQUALS = 1e-6;
 	/** complex eigenvalues. */
 	private Complex[] eigenvalues;
-
 	/** Eigenvectors. */
 	private ArrayFieldVector<Complex>[] eigenvectors;
 	/** Cached value of V. */
@@ -281,7 +282,7 @@ public class ComplexEigenDecomposition {
 		// testing A*V = V*D
 		FieldMatrix<Complex> AV = matrixC.multiply(getV());
 		FieldMatrix<Complex> VD = getV().multiply(getD());
-		if (!equalsWithPrecision(AV, VD, EPSILON)) {
+		if (!equalsWithPrecision(AV, VD, EPSILON_EQUALS)) {
 			throw new MathRuntimeException(LocalizedCoreFormats.CONSTRAINT,
 					"Erro checking definition "
 							+ matrixC.multiply(getV()).toString() + " "

--- a/hipparchus-core/src/main/java/org/hipparchus/linear/OrderedComplexEigenDecomposition.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/OrderedComplexEigenDecomposition.java
@@ -1,8 +1,8 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Hipparchus project under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
+ * The Hipparchus project licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *

--- a/hipparchus-core/src/main/java/org/hipparchus/linear/OrderedComplexEigenDecomposition.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/OrderedComplexEigenDecomposition.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hipparchus.linear;
+
+import java.util.TreeSet;
+
+import org.hipparchus.complex.Complex;
+import org.hipparchus.complex.ComplexComparator;
+
+/**
+ * Given a matrix A, it computes a complex eigen decomposition A = VDV^{T}.
+ * 
+ * It ensures that eigen values in the diagonal of D are in ascending order.
+ * 
+ */
+public class OrderedComplexEigenDecomposition extends ComplexEigenDecomposition {
+
+	/**
+	 * Constructor for the decomposition.
+	 * 
+	 * @param matrix
+	 *            real matrix.
+	 */
+	public OrderedComplexEigenDecomposition(final RealMatrix matrix) {
+		super(matrix);
+
+		final FieldMatrix<Complex> D = this.getD();
+		final FieldMatrix<Complex> V = this.getV();
+
+		// getting eigen values
+		TreeSet<Complex> eigenValues = new TreeSet<Complex>(
+				new ComplexComparator());
+		for (int ij = 0; ij < matrix.getRowDimension(); ij++) {
+			eigenValues.add(D.getEntry(ij, ij));
+		}
+
+		// ordering
+		for (int ij = 0; ij < matrix.getRowDimension() - 1; ij++) {
+			final Complex eigValue = eigenValues.pollFirst();
+			int currentIndex = -1;
+			// searching the current index
+			for (currentIndex = ij; currentIndex < matrix.getRowDimension(); currentIndex++) {
+				Complex compCurrent = D.getEntry(currentIndex, currentIndex);
+				if (eigValue.equals(compCurrent)) {
+					break;
+				}
+			}
+
+			if (ij == currentIndex) {
+				continue;
+			}
+
+			// exchanging D
+			Complex previousValue = D.getEntry(ij, ij);
+			D.setEntry(ij, ij, eigValue);
+			D.setEntry(currentIndex, currentIndex, previousValue);
+
+			// exchanging V
+			final Complex[] previousColumnV = V.getColumn(ij);
+			V.setColumn(ij, V.getColumn(currentIndex));
+			V.setColumn(currentIndex, previousColumnV);
+		}
+
+		checkDefinition(matrix);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.hipparchus.linear.EigenDecomposition#getVT()
+	 */
+	public FieldMatrix<Complex> getVT() {
+		return getV().transpose();
+	}
+}

--- a/hipparchus-core/src/main/java/org/hipparchus/linear/OrderedEigenDecomposition.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/OrderedEigenDecomposition.java
@@ -1,8 +1,8 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Hipparchus project under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
+ * The Hipparchus project licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *

--- a/hipparchus-core/src/main/java/org/hipparchus/linear/OrderedEigenDecomposition.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/OrderedEigenDecomposition.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hipparchus.linear;
+
+import java.util.TreeSet;
+
+import org.hipparchus.complex.Complex;
+import org.hipparchus.complex.ComplexComparator;
+
+/**
+ * Given a matrix A, it computes an eigen decomposition A = VDV^{T}.
+ * 
+ * It also ensures that eigen values in the diagonal of D are in ascending
+ * order.
+ * 
+ */
+public class OrderedEigenDecomposition extends EigenDecomposition {
+
+	/**
+	 * Constructor using the EigenDecomposition as starting point for ordering.
+	 * 
+	 * @param matrix
+	 */
+	public OrderedEigenDecomposition(final RealMatrix matrix) {
+		super(matrix);
+
+		final RealMatrix D = this.getD();
+		final RealMatrix V = this.getV();
+
+		// getting eigen values
+		TreeSet<Complex> eigenValues = new TreeSet<Complex>(
+				new ComplexComparator());
+		for (int ij = 0; ij < matrix.getRowDimension(); ij++) {
+			eigenValues.add(new Complex(getRealEigenvalue(ij),
+					getImagEigenvalue(ij)));
+		}
+
+		// ordering
+		for (int ij = 0; ij < matrix.getRowDimension() - 1; ij++) {
+			final Complex eigValue = eigenValues.pollFirst();
+			int currentIndex = -1;
+			// searching the current index
+			for (currentIndex = ij; currentIndex < matrix.getRowDimension(); currentIndex++) {
+				Complex compCurrent = null;
+				if (currentIndex == 0) {
+					compCurrent = new Complex(D.getEntry(currentIndex,
+							currentIndex), D.getEntry(currentIndex + 1,
+							currentIndex));
+				} else if (currentIndex + 1 == matrix.getRowDimension()) {
+					compCurrent = new Complex(D.getEntry(currentIndex,
+							currentIndex), D.getEntry(currentIndex - 1,
+							currentIndex));
+				} else {
+					if (D.getEntry(currentIndex - 1, currentIndex) != 0) {
+						compCurrent = new Complex(D.getEntry(currentIndex,
+								currentIndex), D.getEntry(currentIndex - 1,
+								currentIndex));
+					} else {
+						compCurrent = new Complex(D.getEntry(currentIndex,
+								currentIndex), D.getEntry(currentIndex + 1,
+								currentIndex));
+
+					}
+
+				}
+
+				if (eigValue.equals(compCurrent)) {
+					break;
+				}
+			}
+
+			if (ij == currentIndex) {
+				continue;
+			}
+
+			// exchanging D
+			Complex previousValue = null;
+			if (ij == 0) {
+				previousValue = new Complex(D.getEntry(ij, ij), D.getEntry(
+						ij + 1, ij));
+			} else if (ij + 1 == matrix.getRowDimension()) {
+				previousValue = new Complex(D.getEntry(ij, ij), D.getEntry(
+						ij - 1, ij));
+			} else {
+				if (D.getEntry(ij - 1, ij) != 0) {
+					previousValue = new Complex(D.getEntry(ij, ij), D.getEntry(
+							ij - 1, ij));
+				} else {
+					previousValue = new Complex(D.getEntry(ij, ij), D.getEntry(
+							ij + 1, ij));
+
+				}
+			}
+			// moved eigenvalue
+			D.setEntry(ij, ij, eigValue.getReal());
+			if (ij == 0) {
+				D.setEntry(ij + 1, ij, eigValue.getImaginary());
+			} else if ((ij + 1) == matrix.getRowDimension()) {
+				D.setEntry(ij - 1, ij, eigValue.getImaginary());
+			} else {
+				if (eigValue.getImaginary() > 0) {
+					D.setEntry(ij - 1, ij, eigValue.getImaginary());
+					D.setEntry(ij + 1, ij, 0);
+				} else {
+					D.setEntry(ij + 1, ij, eigValue.getImaginary());
+					D.setEntry(ij - 1, ij, 0);
+				}
+			}
+			// previous eigen value
+			D.setEntry(currentIndex, currentIndex, previousValue.getReal());
+			if (currentIndex == 0) {
+				D.setEntry(currentIndex + 1, currentIndex,
+						previousValue.getImaginary());
+			} else if ((currentIndex + 1) == matrix.getRowDimension()) {
+				D.setEntry(currentIndex - 1, currentIndex,
+						previousValue.getImaginary());
+			} else {
+				if (previousValue.getImaginary() > 0) {
+					D.setEntry(currentIndex - 1, currentIndex,
+							previousValue.getImaginary());
+					D.setEntry(currentIndex + 1, currentIndex, 0);
+				} else {
+					D.setEntry(currentIndex + 1, currentIndex,
+							previousValue.getImaginary());
+					D.setEntry(currentIndex - 1, currentIndex, 0);
+				}
+			}
+
+			// exchanging V
+			final double[] previousColumnV = V.getColumn(ij);
+			V.setColumn(ij, V.getColumn(currentIndex));
+			V.setColumn(currentIndex, previousColumnV);
+		}
+
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.hipparchus.linear.EigenDecomposition#getVT()
+	 */
+	public RealMatrix getVT() {
+		return getV().transpose();
+	}
+}

--- a/hipparchus-core/src/main/java/org/hipparchus/linear/RiccatiEquationSolver.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/RiccatiEquationSolver.java
@@ -1,8 +1,8 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Hipparchus project under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
+ * The Hipparchus project licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *

--- a/hipparchus-core/src/main/java/org/hipparchus/linear/RiccatiEquationSolver.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/RiccatiEquationSolver.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hipparchus.linear;
+
+/**
+ * 
+ * An algebraic Riccati equation is a type of nonlinear equation that arises in
+ * the context of infinite-horizon optimal control problems in continuous time
+ * or discrete time.
+ * 
+ * The continuous time algebraic Riccati equation (CARE):
+ * 
+ * A^{T}X+XA-XBR^{-1}B^{T}X+Q=0\
+ * 
+ * And the respective linear controller is:
+ * 
+ * K = R^{-1}B^{T}P
+ * 
+ * A solver receives A, B, Q and R and computes P and K.
+ * 
+ */
+public interface RiccatiEquationSolver {
+
+	/**
+	 * @return the p
+	 */
+	public abstract RealMatrix getP();
+
+	/**
+	 * @return the k
+	 */
+	public abstract RealMatrix getK();
+
+}

--- a/hipparchus-core/src/main/java/org/hipparchus/linear/RiccatiEquationSolverImpl.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/RiccatiEquationSolverImpl.java
@@ -1,0 +1,328 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hipparchus.linear;
+
+import org.hipparchus.complex.Complex;
+import org.hipparchus.exception.LocalizedCoreFormats;
+import org.hipparchus.exception.MathIllegalArgumentException;
+import org.hipparchus.exception.MathRuntimeException;
+import org.hipparchus.util.FastMath;
+
+/**
+ * 
+ * This solver computes the solution using the following approach:
+ * 
+ * 1. Compute the Hamiltonian matrix 2. Extract its complex eigen vectors (not
+ * the best solution, a better solution would be ordered Schur transformation)
+ * 3. Approximate the initial solution given by 2 using the Kleinman algorithm
+ * (an iterative method)
+ */
+public class RiccatiEquationSolverImpl implements RiccatiEquationSolver {
+
+	/** Internally used maximum iterations. */
+	private static final int MAX_ITERATIONS = 100;
+
+	/** Internally used epsilon criteria. */
+	private static final double EPSILON = 1e-8;
+
+	/** The solution of the algebraic Riccati equation. */
+	private final RealMatrix P;
+
+	/** The computed K. */
+	private final RealMatrix K;
+
+	/**
+	 * Constructor of the solver. A and B should be compatible. B and R must be
+	 * multiplicative compatible. A and Q must be multiplicative compatible. R
+	 * must be invertible.
+	 * 
+	 * @param A
+	 *            matrix A.
+	 * @param B
+	 *            matrix B.
+	 * @param Q
+	 *            matrix Q.
+	 * @param R
+	 *            matrix R.
+	 */
+	public RiccatiEquationSolverImpl(final RealMatrix A, final RealMatrix B,
+			final RealMatrix Q, final RealMatrix R) {
+
+		// checking A
+		if (!A.isSquare()) {
+			throw new MathIllegalArgumentException(
+					LocalizedCoreFormats.CONSTRAINT, "A must be square");
+		}
+		if (A.getColumnDimension() != B.getRowDimension()) {
+			throw new MathIllegalArgumentException(
+					LocalizedCoreFormats.CONSTRAINT,
+					"A and B must be compatible");
+		}
+		MatrixUtils.checkMultiplicationCompatible(B, R);
+		MatrixUtils.checkMultiplicationCompatible(A, Q);
+
+		// checking R
+		final SingularValueDecomposition svd = new SingularValueDecomposition(R);
+		if (!svd.getSolver().isNonSingular()) {
+			throw new MathIllegalArgumentException(
+					LocalizedCoreFormats.CONSTRAINT, "R must be inversible");
+		}
+		// checking condition number
+		if (svd.getConditionNumber() > 2) {
+			// logger.error("R is an ill-conditioned matrix {}",
+			// svd.getConditionNumber());
+		}
+
+		final RealMatrix R_inv = svd.getSolver().getInverse();
+
+		P = computeP(A, B, Q, R, R_inv, MAX_ITERATIONS, EPSILON);
+
+		K = R_inv.multiply(B.transpose()).multiply(P);
+	}
+
+	/**
+	 * Compute an initial stable solution and then applies the Kleinman
+	 * algorithm to approximate it using an EPSILON.
+	 * 
+	 * @param A
+	 *            matrix A.
+	 * @param B
+	 *            matrix B.
+	 * @param Q
+	 *            matrix Q.
+	 * @param R
+	 *            matrix R.
+	 * @param R_inv
+	 *            inverse of matrix R.
+	 * @param maxIterations
+	 *            maximum number of iterations.
+	 * @param epsilon
+	 *            epsilon to be used.
+	 * @return matrix P, solution of the algebraic Riccati equation.
+	 */
+	private RealMatrix computeP(final RealMatrix A, final RealMatrix B,
+			final RealMatrix Q, final RealMatrix R, final RealMatrix R_inv,
+			final int maxIterations, final double epsilon) {
+		final RealMatrix P_ = computeInitialP(A, B, Q, R, R_inv);
+		return approximateP(A, B, Q, R, R_inv, P_, maxIterations, epsilon);
+	}
+
+	/**
+	 * Compute initial P using the Hamiltonian and the ordered eigen values
+	 * decomposition.
+	 * 
+	 * @param A
+	 *            matrix A.
+	 * @param B
+	 *            matrix B.
+	 * @param Q
+	 *            matrix Q.
+	 * @param R
+	 *            matrix R.
+	 * @param R_inv
+	 *            inverse of matrix R.
+	 * @return
+	 */
+	private RealMatrix computeInitialP(final RealMatrix A, final RealMatrix B,
+			final RealMatrix Q, final RealMatrix R, final RealMatrix R_inv) {
+		final RealMatrix B_tran = B.transpose();
+
+		// computing the Hamiltonian Matrix
+		final RealMatrix m11 = A;
+		final RealMatrix m12 = B.multiply(R_inv).multiply(B_tran)
+				.scalarMultiply(-1).scalarAdd(0);
+		final RealMatrix m21 = Q.scalarMultiply(-1).scalarAdd(0);
+		final RealMatrix m22 = A.transpose().scalarMultiply(-1).scalarAdd(0);
+		if (m11.getRowDimension() != m12.getRowDimension()) {
+			throw new MathIllegalArgumentException(
+					LocalizedCoreFormats.CONSTRAINT, "Dimensions must match");
+		}
+		if (m21.getRowDimension() != m22.getRowDimension()) {
+			throw new MathIllegalArgumentException(
+					LocalizedCoreFormats.CONSTRAINT, "Dimensions must match");
+		}
+		if (m11.getColumnDimension() != m21.getColumnDimension()) {
+			throw new MathIllegalArgumentException(
+					LocalizedCoreFormats.CONSTRAINT, "Dimensions must match");
+		}
+		if (m21.getColumnDimension() != m22.getColumnDimension()) {
+			throw new MathIllegalArgumentException(
+					LocalizedCoreFormats.CONSTRAINT, "Dimensions must match");
+		}
+
+		// defining M
+		final RealMatrix m = MatrixUtils.createRealMatrix(m11.getRowDimension()
+				+ m21.getRowDimension(),
+				m11.getColumnDimension() + m12.getColumnDimension());
+		// defining submatrixes
+		m.setSubMatrix(m11.getData(), 0, 0);
+		m.setSubMatrix(m12.getData(), 0, m11.getColumnDimension());
+		m.setSubMatrix(m21.getData(), m11.getRowDimension(), 0);
+		m.setSubMatrix(m22.getData(), m11.getRowDimension(),
+				m11.getColumnDimension());
+
+		// eigen decomposition
+		// numerically bad, but it is used for the initial stable solution for
+		// the
+		// Kleinman Algorithm
+		// it must be ordered in order to work with submatrices
+		final OrderedComplexEigenDecomposition eigenDecomposition = new OrderedComplexEigenDecomposition(
+				m);
+		final FieldMatrix<Complex> u = eigenDecomposition.getV();
+
+		// solving linear system
+		// P = U_21*U_11^-1
+		final FieldMatrix<Complex> u11 = u.getSubMatrix(0,
+				m11.getRowDimension() - 1, 0, m11.getColumnDimension() - 1);
+		final FieldMatrix<Complex> u21 = u.getSubMatrix(m11.getRowDimension(),
+				2 * m11.getRowDimension() - 1, 0, m11.getColumnDimension() - 1);
+
+		final FieldDecompositionSolver<Complex> solver = new FieldLUDecomposition<Complex>(
+				u11).getSolver();
+
+		if (!solver.isNonSingular()) {
+			throw new MathRuntimeException(LocalizedCoreFormats.CONSTRAINT,
+					"Singular matrix");
+		}
+
+		// solving U_11^{-1}
+		FieldMatrix<Complex> u11_inv = solver.getInverse();
+
+		// P = U_21*U_11^-1
+		FieldMatrix<Complex> p = u21.multiply(u11_inv);
+
+		// converting to realmatrix - ignoring precision errors in imaginary
+		// components
+		final RealMatrix p_real = convertToRealMatrix(p, Double.MAX_VALUE);
+		return p_real;
+	}
+
+	/**
+	 * Applies the Kleinman's algorithm.
+	 * 
+	 * @param A
+	 * @param B
+	 * @param Q
+	 * @param R
+	 */
+	private RealMatrix approximateP(final RealMatrix A, final RealMatrix B,
+			final RealMatrix Q, final RealMatrix R, final RealMatrix R_inv,
+			final RealMatrix P, final int maxIterations, final double epsilon) {
+		RealMatrix K_ = null;
+		RealMatrix P_ = P;
+
+		double error = 1;
+		int i = 1;
+		while (error > epsilon) {
+			K_ = P_.multiply(B).multiply(R_inv).scalarMultiply(-1);
+
+			// X = AA+BB*K1';
+			final RealMatrix X = A.add(B.multiply(K_.transpose()));
+			// Y = -K1*RR*K1' - QQ;
+			final RealMatrix Y = K_.multiply(R).multiply(K_.transpose())
+					.scalarMultiply(-1).subtract(Q);
+
+			final Array2DRowRealMatrix X_ = (Array2DRowRealMatrix) X
+					.transpose();
+			final Array2DRowRealMatrix Y_ = (Array2DRowRealMatrix) Y;
+			final Array2DRowRealMatrix eyeX = (Array2DRowRealMatrix) MatrixUtils
+					.createRealIdentityMatrix(X_.getRowDimension());
+
+			// X1=kron(X',eye(size(X))) + kron(eye(size(X)),X');
+			final RealMatrix X__ = X_.kroneckerProduct(eyeX).add(
+					eyeX.kroneckerProduct(X_));
+			// Y1=reshape(Y,prod(size(Y)),1); %%stack
+			final RealMatrix Y__ = Y_.stack();
+
+			// PX = inv(X1)*Y1;
+			// sensitive to numerical erros
+			// final RealMatrix PX = MatrixUtils.inverse(X__).multiply(Y__);
+			DecompositionSolver solver = new LUDecomposition(X__).getSolver();
+			if (!solver.isNonSingular()) {
+				throw new MathRuntimeException(LocalizedCoreFormats.CONSTRAINT,
+						"Singular matrix");
+			}
+			final RealMatrix PX = solver.solve(Y__);
+
+			// P = reshape(PX,sqrt(length(PX)),sqrt(length(PX))); %%unstack
+			final RealMatrix P__ = ((Array2DRowRealMatrix) PX).unstackSquare();
+
+			// aerror = norm(P - P1);
+			final RealMatrix diff = P__.subtract(P_);
+			// calculationg l2 norm
+			final SingularValueDecomposition svd = new SingularValueDecomposition(
+					diff);
+			error = svd.getNorm();
+
+			P_ = P__;
+			i++;
+			if (i > maxIterations) {
+				throw new MathRuntimeException(LocalizedCoreFormats.CONSTRAINT,
+						"It does not converge");
+			}
+		}
+
+		return P_;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.hipparchus.linear.RiccatiEquationSolver1#getP()
+	 */
+	public RealMatrix getP() {
+		return P;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.hipparchus.linear.RiccatiEquationSolver1#getK()
+	 */
+	public RealMatrix getK() {
+		return K;
+	}
+
+	/**
+	 * Converts a given complex matrix into a real matrix taking into account a
+	 * precision for the imaginary components.
+	 * 
+	 * @param matrix
+	 *            complex field matrix.
+	 * @return real matrix.
+	 */
+	private RealMatrix convertToRealMatrix(FieldMatrix<Complex> matrix,
+			Double error) {
+		final RealMatrix toRet = MatrixUtils.createRealMatrix(
+				matrix.getRowDimension(), matrix.getRowDimension());
+		for (int i = 0; i < toRet.getRowDimension(); i++) {
+			for (int j = 0; j < toRet.getColumnDimension(); j++) {
+				Complex c = matrix.getEntry(i, j);
+				if (c.getImaginary() != 0
+						&& FastMath.abs(c.getImaginary()) > error) {
+					throw new MathRuntimeException(
+							LocalizedCoreFormats.CONSTRAINT,
+							"The resulting matrix is not a real matrix (" + i
+									+ "," + j + ") = " + c + " (error=" + error
+									+ ")");
+				}
+				toRet.setEntry(i, j, c.getReal());
+			}
+		}
+		return toRet;
+	}
+}

--- a/hipparchus-core/src/main/java/org/hipparchus/linear/RiccatiEquationSolverImpl.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/RiccatiEquationSolverImpl.java
@@ -1,8 +1,8 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Hipparchus project under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
+ * The Hipparchus project licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *

--- a/hipparchus-core/src/test/java/org/hipparchus/complex/ComplexComparatorTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/complex/ComplexComparatorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hipparchus.complex;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ComplexComparatorTest {
+
+	private final ComplexComparator comp = new ComplexComparator();
+	private Complex o1 = new Complex(1, 1);
+	private Complex o11 = new Complex(1, 1);
+	private Complex o2 = new Complex(1, 0);
+	private Complex o3 = new Complex(2, 0);
+
+	@Test
+	public void test() {
+		assertEquals("ok", comp.compare(o1, o2), -1 * comp.compare(o2, o1));
+	}
+
+	@Test
+	public void test2() {
+		assertEquals("ok",
+				((comp.compare(o1, o2) > 0) && (comp.compare(o2, o3) > 0)),
+				comp.compare(o1, o3) > 0);
+	}
+
+	@Test
+	public void test3() {
+		assertEquals("ok", ((comp.compare(o1, o11) == 0)),
+				comp.compare(o1, o2) == comp.compare(o11, o2));
+	}
+
+	@Test
+	public void test4() {
+		assertTrue("ok", (comp.compare(o1, o11) == 0));
+	}
+}

--- a/hipparchus-core/src/test/java/org/hipparchus/complex/ComplexComparatorTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/complex/ComplexComparatorTest.java
@@ -1,8 +1,8 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Hipparchus project under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
+ * The Hipparchus project licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *

--- a/hipparchus-core/src/test/java/org/hipparchus/linear/Array2DRowRealMatrixTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/linear/Array2DRowRealMatrixTest.java
@@ -21,6 +21,11 @@
  */
 package org.hipparchus.linear;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.text.DecimalFormat;
+
 import org.hipparchus.UnitTestUtils;
 import org.hipparchus.exception.LocalizedCoreFormats;
 import org.hipparchus.exception.MathIllegalArgumentException;
@@ -1135,5 +1140,83 @@ public final class Array2DRowRealMatrixTest {
 //              System.out.println(os);
 //          }
 //    }
+
+	static private final RealMatrixFormat f = new RealMatrixFormat("", "",
+			"\n", "", "", "\t\t", new DecimalFormat(
+					" ##############0.0000;-##############0.0000"));
+
+	@Test
+	public void testKroneckerProduct() {
+		// AA = [-3 2;1 1];
+		// BB = [1 0;0 1];
+
+		RealMatrix A = MatrixUtils.createRealMatrix(new double[][] { { -3, 2 },
+				{ 1, 1 } });
+		Array2DRowRealMatrix A_ = (Array2DRowRealMatrix)
+				A;
+
+		RealMatrix B = MatrixUtils.createRealMatrix(new double[][] { { 1, 0 },
+				{ 0, 1 } });
+
+		RealMatrix C = A_.kroneckerProduct(B);
+
+		assertNotNull(C);
+
+		RealMatrix C_expected = MatrixUtils.createRealMatrix(new double[][] {
+				{ -3, 0, 2, 0 }, { -0, -3, 0, 2 }, { 1, 0, 1, 0 },
+				{ 0, 1, 0, 1 } });
+		assertEquals(f.format(C_expected), f.format(C.scalarAdd(0)));
+
+	}
+
+	@Test
+	public void testStack() {
+		// AA = [-3 2;1 1];
+
+		RealMatrix A = MatrixUtils.createRealMatrix(new double[][] { { -3, 2 },
+				{ 1, 1 } });
+		Array2DRowRealMatrix A_ = (Array2DRowRealMatrix)
+				A;
+
+		RealMatrix C = A_.stack();
+
+		assertNotNull(C);
+
+		RealMatrix C_expected = MatrixUtils.createRealMatrix(new double[][] {
+				{ -3 }, { 1 }, { 2 }, { 1 } });
+		assertEquals(f.format(C_expected), f.format(C));
+
+	}
+
+	@Test
+	public void testUnstackSquare() {
+		// AA = [-3 ;2;1; 1];
+
+		RealMatrix A = MatrixUtils.createRealMatrix(new double[][] { { -3 },
+				{ 1 }, { 2 }, { 1 } });
+		Array2DRowRealMatrix A_ = (Array2DRowRealMatrix)
+				A;
+
+		RealMatrix C = A_.unstackSquare();
+
+		assertNotNull(C);
+
+		RealMatrix C_expected = MatrixUtils.createRealMatrix(new double[][] {
+				{ -3, 2 }, { 1, 1 } });
+		assertEquals(f.format(C_expected), f.format(C));
+
+	}
+
+	@Test(expected = MathIllegalArgumentException.class)
+	public void testUnstackNotsquare() {
+		// AA = [-3 ;2;1; 1;1];
+
+		RealMatrix A = MatrixUtils.createRealMatrix(new double[][] { { -3 },
+				{ 1 }, { 2 }, { 1 }, { 1 } });
+		Array2DRowRealMatrix A_ = (Array2DRowRealMatrix)
+				A;
+
+		A_.unstackSquare();
+	}
 }
 

--- a/hipparchus-core/src/test/java/org/hipparchus/linear/ComplexEigenDecompositionTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/linear/ComplexEigenDecompositionTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hipparchus.linear;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.hipparchus.complex.Complex;
+import org.junit.Test;
+
+public class ComplexEigenDecompositionTest {
+
+	private final RealMatrix A = MatrixUtils.createRealMatrix(new double[][] {
+			{ 3, -2 }, { 4, -1 } });
+
+	@Test
+	public void testGetEigenValues() {
+		ComplexEigenDecomposition eigenDecomp = new ComplexEigenDecomposition(A);
+		Complex ev1 = eigenDecomp.getEigenvalues()[0];
+		Complex ev2 = eigenDecomp.getEigenvalues()[1];
+		assertEquals("It must be equals", new Complex(1, 2), ev1);
+		assertEquals("It must be equals", new Complex(1, -2), ev2);
+	}
+
+	@Test
+	public void testHasComplexEigenValues() {
+		ComplexEigenDecomposition eigenDecomp = new ComplexEigenDecomposition(A);
+		assertTrue("It must be equals", eigenDecomp.hasComplexEigenvalues());
+	}
+
+	@Test
+	public void testGetDeterminant() {
+		ComplexEigenDecomposition eigenDecomp = new ComplexEigenDecomposition(A);
+		assertEquals("It must be equals", 5, eigenDecomp.getDeterminant(),
+				1E-10d);
+	}
+
+	@Test
+	public void testGetEigenVectors() {
+		ComplexEigenDecomposition eigenDecomp = new ComplexEigenDecomposition(A);
+		FieldVector<Complex> ev1 = eigenDecomp.getEigenvector(0);
+		FieldVector<Complex> ev2 = eigenDecomp.getEigenvector(1);
+		assertEquals("It must be equals", new Complex(.5, .5), ev1.getEntry(0));
+		assertEquals("It must be equals", new Complex(1), ev1.getEntry(1));
+		assertEquals("It must be equals", new Complex(.5, -.5), ev2.getEntry(0));
+		assertEquals("It must be equals", new Complex(1), ev2.getEntry(1));
+	}
+
+	@Test
+	public void testGetV() {
+		ComplexEigenDecomposition eigenDecomp = new ComplexEigenDecomposition(A);
+		FieldMatrix<Complex> V = eigenDecomp.getV();
+		assertEquals("It must be equals", new Complex(.5, .5), V.getEntry(0, 0));
+		assertEquals("It must be equals", new Complex(.5, -.5),
+				V.getEntry(0, 1));
+		assertEquals("It must be equals", new Complex(1), V.getEntry(1, 0));
+		assertEquals("It must be equals", new Complex(1), V.getEntry(1, 1));
+	}
+
+	@Test
+	public void testGetVT() {
+		ComplexEigenDecomposition eigenDecomp = new ComplexEigenDecomposition(A);
+		FieldMatrix<Complex> V = eigenDecomp.getVT();
+		assertEquals("It must be equals", new Complex(.5, .5),
+				V.getEntry(0, 0));
+		assertEquals("It must be equals", new Complex(.5, -.5), V.getEntry(1, 0));
+		assertEquals("It must be equals", new Complex(1), V.getEntry(0, 1));
+		assertEquals("It must be equals", new Complex(1), V.getEntry(1, 1));
+	}
+
+	@Test
+	public void testGetD() {
+		ComplexEigenDecomposition eigenDecomp = new ComplexEigenDecomposition(A);
+		FieldMatrix<Complex> D = eigenDecomp.getD();
+		assertEquals("It must be equals", new Complex(1, 2), D.getEntry(0, 0));
+		assertEquals("It must be equals", new Complex(0), D.getEntry(0, 1));
+		assertEquals("It must be equals", new Complex(0), D.getEntry(0, 1));
+		assertEquals("It must be equals", new Complex(1, -2), D.getEntry(1, 1));
+	}
+
+	@Test
+	public void testDefinition() {
+		ComplexEigenDecomposition eigenDecomp = new ComplexEigenDecomposition(A);
+
+		FieldMatrix<Complex> A = MatrixUtils.createFieldMatrix(new Complex[][] {
+				{ new Complex(3, 0), new Complex(-2, 0) },
+				{ new Complex(4, 0), new Complex(-1, 0) } });
+
+		// testing AV = lamba V - [0]
+		assertEquals(A.operate(eigenDecomp.getEigenvector(0)), eigenDecomp
+				.getEigenvector(0).mapMultiply(eigenDecomp.getEigenvalues()[0]));
+
+		// testing AV = lamba V - [1]
+		assertEquals(A.operate(eigenDecomp.getEigenvector(1)), eigenDecomp
+				.getEigenvector(1).mapMultiply(eigenDecomp.getEigenvalues()[1]));
+
+		// checking definition of the decomposition A*V = V*D
+		assertEquals(A.multiply(eigenDecomp.getV()), eigenDecomp.getV()
+				.multiply(eigenDecomp.getD()));
+	}
+
+}

--- a/hipparchus-core/src/test/java/org/hipparchus/linear/ComplexEigenDecompositionTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/linear/ComplexEigenDecompositionTest.java
@@ -1,8 +1,8 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Hipparchus project under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
+ * The Hipparchus project licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *

--- a/hipparchus-core/src/test/java/org/hipparchus/linear/OrderedComplexEigenDecompositionTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/linear/OrderedComplexEigenDecompositionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hipparchus.linear;
+
+import static org.junit.Assert.assertEquals;
+
+import org.hipparchus.complex.Complex;
+import org.junit.Test;
+
+public class OrderedComplexEigenDecompositionTest {
+
+	private final RealMatrix A = MatrixUtils.createRealMatrix(new double[][] {
+			{ 3, -2 }, { 4, -1 } });
+
+	@Test
+	public void testDefinition() {
+		OrderedComplexEigenDecomposition eigenDecomp = new OrderedComplexEigenDecomposition(
+				A);
+
+		FieldMatrix<Complex> A = MatrixUtils.createFieldMatrix(new Complex[][] {
+				{ new Complex(3, 0), new Complex(-2, 0) },
+				{ new Complex(4, 0), new Complex(-1, 0) } });
+
+		// testing AV = lamba V - [0]
+		assertEquals(A.operate(eigenDecomp.getEigenvector(0)), eigenDecomp
+				.getEigenvector(0).mapMultiply(eigenDecomp.getEigenvalues()[0]));
+
+		// testing AV = lamba V - [1]
+		assertEquals(A.operate(eigenDecomp.getEigenvector(1)), eigenDecomp
+				.getEigenvector(1).mapMultiply(eigenDecomp.getEigenvalues()[1]));
+
+		// checking definition of the decomposition A*V = V*D
+		assertEquals(A.multiply(eigenDecomp.getV()), eigenDecomp.getV()
+				.multiply(eigenDecomp.getD()));
+	}
+}

--- a/hipparchus-core/src/test/java/org/hipparchus/linear/OrderedComplexEigenDecompositionTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/linear/OrderedComplexEigenDecompositionTest.java
@@ -1,8 +1,8 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Hipparchus project under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
+ * The Hipparchus project licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *

--- a/hipparchus-core/src/test/java/org/hipparchus/linear/OrderedEigenDecompositionTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/linear/OrderedEigenDecompositionTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hipparchus.linear;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.text.DecimalFormat;
+
+import org.junit.Test;
+
+public class OrderedEigenDecompositionTest {
+
+	static private final RealMatrixFormat f = new RealMatrixFormat("", "",
+			"\n", "", "", "\t\t", new DecimalFormat(
+					" ##############0.0000;-##############0.0000"));
+
+	/**
+	 * 
+	 */
+	@Test
+	public void testOrdEigenDecomposition_Real() {
+		// AA = [1 2;1 -3];
+
+		RealMatrix A = MatrixUtils.createRealMatrix(new double[][] { { 1, 2 },
+				{ 1, -3 } });
+
+		OrderedEigenDecomposition ordEig = new OrderedEigenDecomposition(A);
+
+		assertNotNull(ordEig.getD());
+		assertNotNull(ordEig.getV());
+
+		RealMatrix D_expected = MatrixUtils.createRealMatrix(new double[][] {
+				{ -3.4495, 0 }, { 0, 1.4495 } });
+
+		RealMatrix V_expected = MatrixUtils.createRealMatrix(new double[][] {
+				{ -0.4184, 0.9757 }, { 0.9309, 0.2193 } });
+
+		assertEquals(f.format(D_expected), f.format(ordEig.getD()));
+		assertEquals(f.format(V_expected), f.format(ordEig.getV()));
+
+		// checking definition of the decomposition A = V*D*inv(V)
+		assertEquals(
+				f.format(A),
+				f.format(ordEig.getV().multiply(ordEig.getD())
+						.multiply(MatrixUtils.inverse(ordEig.getV()))
+						.scalarAdd(0)));
+	}
+
+	/**
+	 * 
+	 */
+	@Test
+	public void testOrdEigenDecomposition_Imaginary() {
+		// AA = [3 -2;4 -1];
+
+		RealMatrix A = MatrixUtils.createRealMatrix(new double[][] { { 3, -2 },
+				{ 4, -1 } });
+
+		OrderedEigenDecomposition ordEig = new OrderedEigenDecomposition(A);
+
+		assertNotNull(ordEig.getD());
+		assertNotNull(ordEig.getV());
+
+		RealMatrix D_expected = MatrixUtils.createRealMatrix(new double[][] {
+				{ 1, 2 }, { -2, 1 } });
+
+		RealMatrix V_expected = MatrixUtils.createRealMatrix(new double[][] {
+				{ -0.5, 0.5 }, { 0, 1 } });
+
+		assertEquals(f.format(D_expected), f.format(ordEig.getD()));
+		assertEquals(f.format(V_expected), f.format(ordEig.getV()));
+
+		// checking definition of the decomposition A = V*D*inv(V)
+		assertEquals(
+				f.format(A),
+				f.format(ordEig.getV().multiply(ordEig.getD())
+						.multiply(MatrixUtils.inverse(ordEig.getV()))
+						.scalarAdd(0)));
+	}
+
+	/**
+	 * 
+	 */
+	@Test
+	public void testOrdEigenDecomposition_Imaginary_33() {
+		// AA = [3 -2 0;4 -1 0;1 1 1];
+
+		RealMatrix A = MatrixUtils.createRealMatrix(new double[][] {
+				{ 3, -2, 0 }, { 4, -1, 0 }, { 3, -2, 0 } });
+
+		OrderedEigenDecomposition ordEig = new OrderedEigenDecomposition(A);
+
+		assertNotNull(ordEig.getD());
+		assertNotNull(ordEig.getV());
+
+		RealMatrix D_expected = MatrixUtils.createRealMatrix(new double[][] {
+				{ 0, 0, 0 }, { 0, 1, 2 }, { 0, -2, 1 } });
+
+		RealMatrix V_expected = MatrixUtils.createRealMatrix(new double[][] {
+				{ -0.00001, -0.4690, -0.9381 }, { -0.0, -1.4071, -0.4690 },
+				{ 1.4142, -0.4690, -0.9381 } });
+
+		assertEquals(f.format(D_expected), f.format(ordEig.getD()));
+		assertEquals(f.format(V_expected), f.format(ordEig.getV()));
+
+		// checking definition of the decomposition A = V*D*inv(V)
+		assertEquals(
+				A.subtract(
+						ordEig.getV().multiply(ordEig.getD())
+								.multiply(MatrixUtils.inverse(ordEig.getV())))
+						.getFrobeniusNorm(), 0, 1E-10);
+	}
+
+}

--- a/hipparchus-core/src/test/java/org/hipparchus/linear/OrderedEigenDecompositionTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/linear/OrderedEigenDecompositionTest.java
@@ -1,8 +1,8 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Hipparchus project under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
+ * The Hipparchus project licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *

--- a/hipparchus-core/src/test/java/org/hipparchus/linear/RiccatiEquationSolverTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/linear/RiccatiEquationSolverTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hipparchus.linear;
+
+import static org.junit.Assert.assertEquals;
+
+import java.text.DecimalFormat;
+
+import org.hipparchus.linear.MatrixUtils;
+import org.hipparchus.linear.RealMatrix;
+import org.hipparchus.linear.RealMatrixFormat;
+import org.hipparchus.linear.RiccatiEquationSolverImpl;
+import org.junit.Test;
+
+public class RiccatiEquationSolverTest {
+
+	static private final RealMatrixFormat f = new RealMatrixFormat("", "",
+			"\n", "", "", "\t\t", new DecimalFormat(
+					" ##############0.0000;-##############0.0000"));
+
+	@Test
+	public void test_real_2_2() {
+		// AA = [-3 2;1 1];
+		// BB = [0;1];
+
+		RealMatrix A = MatrixUtils.createRealMatrix(new double[][] { { -3, 2 },
+				{ 1, 1 } });
+
+		RealMatrix B = MatrixUtils.createRealMatrix(new double[][] { { 0 },
+				{ 1 } });
+
+		RealMatrix R = MatrixUtils.createRealIdentityMatrix(1);
+		RealMatrix Q = MatrixUtils.createRealIdentityMatrix(2);
+
+		RiccatiEquationSolver a = new RiccatiEquationSolverImpl(A, B, Q, R);
+
+		RealMatrix P_expected = MatrixUtils.createRealMatrix(new double[][] {
+				{ 0.3221, 0.7407 }, { 0.7407, 3.2277 } });
+
+		assertEquals(f.format(P_expected), f.format(a.getP()));
+
+		// P
+		// 0.3221 0.7407
+		// 0.7407 3.2277
+		// K
+		// 0.7407 3.2277
+	}
+
+	@Test
+	public void test_imaginary_2_2() {
+		// AA = [3 -2;4 -1];
+		// BB = [0;1];
+
+		RealMatrix A = MatrixUtils.createRealMatrix(new double[][] { { 3, -2 },
+				{ 4, -1 } });
+
+		RealMatrix B = MatrixUtils.createRealMatrix(new double[][] { { 0 },
+				{ 1 } });
+
+		RealMatrix R = MatrixUtils.createRealIdentityMatrix(1);
+		RealMatrix Q = MatrixUtils.createRealIdentityMatrix(2);
+
+		RiccatiEquationSolver a = new RiccatiEquationSolverImpl(A, B, Q, R);
+
+		RealMatrix P_expected = MatrixUtils.createRealMatrix(new double[][] {
+				{ 19.7598, -7.6430 }, { -7.6430, 4.7072 } });
+
+		assertEquals(f.format(P_expected), f.format(a.getP()));
+
+		// P
+		// 19.7598 -7.6430
+		// -7.6430 4.7072
+		//
+		// K
+		// -7.6430 4.7072
+
+	}
+
+	@Test
+	public void test_imaginary_6_6() {
+
+		RealMatrix A = MatrixUtils.createRealMatrix(new double[][] {
+				{ 1, 0, 0, 1, 0, 0 }, { 1, 0, 0, 0, 1, 0 },
+				{ 1, 0, 0, 0, 0, 1 }, { 0, 0, 0, 0, 0, 0 },
+				{ 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0 } });
+
+		RealMatrix B = MatrixUtils.createRealMatrix(new double[][] {
+				{ 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 }, { -0.0032, 0, 0 },
+				{ 0, -0.0028, 0 }, { 0, 0, -0.0019 } });
+
+		RealMatrix R = MatrixUtils.createRealIdentityMatrix(3);
+		RealMatrix Q = MatrixUtils.createRealIdentityMatrix(6);
+
+		RiccatiEquationSolver a = new RiccatiEquationSolverImpl(A, B, Q, R);
+
+		RealMatrix P_expected = MatrixUtils.createRealMatrix(new double[][] {
+				{ 2.2791, 0.0036, 0.0045, 2.1121, 0.0628, 0.0982 },
+				{ 0.0036, 0.0002, -0.0000, 0.0017, 0.0029, -0.0011 },
+				{ 0.0045, -0.0000, 0.0003, 0.0022, -0.0011, 0.0034 },
+				{ 2.1121, 0.0017, 0.0022, 2.0307, 0.0305, 0.0479 },
+				{ 0.0628, 0.0029, -0.0011, 0.0305, 0.0746, -0.0387 },
+				{ 0.0982, -0.0011, 0.0034, 0.0479, -0.0387, 0.0967 } });
+
+		assertEquals(f.format(P_expected),
+				f.format(a.getP().scalarMultiply(1e-05)));
+
+		// 1.0e+05 *
+		// 2.2791 0.0036 0.0045 2.1121 0.0628 0.0982
+		// 0.0036 0.0002 -0.0000 0.0017 0.0029 -0.0011
+		// 0.0045 -0.0000 0.0003 0.0022 -0.0011 0.0034
+		// 2.1121 0.0017 0.0022 2.0307 0.0305 0.0479
+		// 0.0628 0.0029 -0.0011 0.0305 0.0746 -0.0387
+		// 0.0982 -0.0011 0.0034 0.0479 -0.0387 0.0967
+	}
+
+	@Test
+	public void test_imaginary_6_6_ill_conditioned() {
+		// A = [0 0 0 1 0 0; 0 0 0 0 1 0; 0 0 0 0 0 1; 0 0 0 0 0 0; 0 0 0 0 0 0;
+		// 0 0 0 0 0 0];
+		// B = [ 0 0 0; 0 0 0; 0 0 0; -0.0032 0 0; 0 -0.0028 0; 0 0 -0.0019];
+		// R= [1 0 0; 0 1 0; 0 0 1];
+		// Q = [1 0 0 0 0 0; 0 1 0 0 0 0; 0 0 1 0 0 0; 0 0 0 1 0 0; 0 0 0 0 1 0;
+		// 0 0 0 0 0 1];
+
+		RealMatrix A = MatrixUtils.createRealMatrix(new double[][] {
+				{ 0, 0, 0, 1, 0, 0 }, { 0, 0, 0, 0, 1, 0 },
+				{ 0, 0, 0, 0, 0, 1 }, { 0, 0, 0, 0, 0, 0 },
+				{ 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0 } });
+
+		RealMatrix B = MatrixUtils.createRealMatrix(new double[][] {
+				{ 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 }, { -0.0032, 0, 0 },
+				{ 0, -0.0028, 0 }, { 0, 0, -0.0019 } });
+
+		RealMatrix R = MatrixUtils.createRealIdentityMatrix(3);
+		RealMatrix Q = MatrixUtils.createRealIdentityMatrix(6);
+		RiccatiEquationSolver a = new RiccatiEquationSolverImpl(A, B, Q, R);
+
+		RealMatrix P_expected = MatrixUtils.createRealMatrix(new double[][] {
+				{ 25.02, -1E-12, 0, 312.5, -1E-12, 0 },
+				{ -1E-12, 26.7448, 0, 0, 357.1429, 0 },
+				{ 0, 0, 32.4597, -1E-12, -1E-12, 526.3158 },
+				{ 312.5, -1E-12, -1E-12, 7818.7475, 0, 0 },
+				{ -1E-12, 357.1429, -1E-12, 0, 9551.7235, -1E-12 },
+				{ 0, 0, 526.3158, 0, -1E-12, 17084.0482 } });
+
+		assertEquals(f.format(P_expected), f.format(a.getP()));
+	}
+
+}

--- a/hipparchus-core/src/test/java/org/hipparchus/linear/RiccatiEquationSolverTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/linear/RiccatiEquationSolverTest.java
@@ -1,8 +1,8 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Hipparchus project under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
+ * The Hipparchus project licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *


### PR DESCRIPTION
Riccati Equation Solver, a proposal for the addition of an algebraic Riccati Equation Solver in the package org.hipparchus.linear.
It also incluses extensions in the Array2DRowRealMatrix to support Kronecker products and ComplexEigenDecomposition.