### PR TITLE
Deploy to nexus

### DIFF
--- a/.CI/README
+++ b/.CI/README
@@ -1,0 +1,1 @@
+A directory for Continuous Integration tooling.

--- a/.CI/maven-settings.xml
+++ b/.CI/maven-settings.xml
@@ -1,0 +1,16 @@
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xsi:schemalocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>ci-releases</id>
+            <username>${env.NEXUS_USERNAME}</username>
+            <password>${env.NEXUS_PASSWORD}</password>
+        </server>
+        <server>
+            <id>ci-snapshots</id>
+            <username>${env.NEXUS_USERNAME}</username>
+            <password>${env.NEXUS_PASSWORD}</password>
+        </server>
+    </servers>
+</settings>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,11 @@
 pipeline {
 
     agent any
+
+    environment {
+        MAVEN_CLI_OPTS = "-s .CI/maven-settings.xml"
+    }
+
     tools {
         maven 'mvn-default'
         jdk   'openjdk-8'
@@ -22,6 +27,15 @@ pipeline {
         stage('Build') {
             steps {
                 sh 'mvn package test install checkstyle:checkstyle'
+             }
+        }
+
+        stage('Deploy') {
+            // Deploy on staging repository
+            // Official deployments are made manually
+            when { branch 'master' }
+            steps {
+                sh 'mvn $MAVEN_CLI_OPTS deploy -DskipTests=true -Pci-deploy'
              }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,8 +35,12 @@ pipeline {
             // Official deployments are made manually
             when { branch 'master' }
             steps {
-                sh 'mvn $MAVEN_CLI_OPTS deploy -DskipTests=true -Pci-deploy'
-             }
+                withCredentials([usernamePassword(credentialsId: 'jenkins-at-nexus',
+                                                  usernameVariable: 'NEXUS_USERNAME',
+                                                  passwordVariable: 'NEXUS_PASSWORD')]) {
+                    sh 'mvn $MAVEN_CLI_OPTS deploy -DskipTests=true -Pci-deploy'
+                }
+            }
         }
 
     }

--- a/hipparchus-parent/pom.xml
+++ b/hipparchus-parent/pom.xml
@@ -54,14 +54,6 @@
   </issueManagement>
 
   <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
     <site>
       <id>publishedSite</id>
       <url>https://hipparchus.org/</url>
@@ -960,7 +952,30 @@
 
   <profiles>
     <profile>
+      <id>ci-deploy</id>
+      <distributionManagement>
+        <repository>
+          <id>ci-releases</id>
+          <url>https://packages.orekit.org/repository/maven-releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>ci-snapshots</id>
+            <url>https://packages.orekit.org/repository/maven-snapshots/</url>
+        </snapshotRepository>
+      </distributionManagement>
+    </profile>
+    <profile>
       <id>release</id>
+      <distributionManagement>
+        <snapshotRepository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+      </distributionManagement>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
This change set brings the ability to deploy Maven artifact onto the Orekit's Nexus instance.

As the changes can be tested effectively only on:

- the `master` branch
- using the official CI/CD plaform

feel free to merge when it does not conflict with any other product related event (delivery?).