### PR TITLE
CI enhancement for forks

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,11 +15,17 @@ jobs:
     - name: Build with Maven
       run: mvn -B -f pom.xml install checkstyle:checkstyle
     - name: SonarQube scan
-      run: mvn -B -f pom.xml sonar:sonar -Dsonar.login=$SONARQUBE_TOKEN -Dsonar.branch.name=${GITHUB_REF##*/}
+      run: |
+        if [ $PROJECT_KEY != 'Hipparchus-Math/hipparchus' ] ; then export KEY_OPTION="-Dsonar.projectKey=${PROJECT_KEY/\//:}" ; fi
+        if [ $PROJECT_KEY != 'Hipparchus-Math/hipparchus' ] ; then export PROJECT_NAME="$PROJECT_NAME ($PROJECT_KEY)" ; fi
+        mvn -B -f pom.xml sonar:sonar -Dsonar.login=$SONARQUBE_TOKEN -Dsonar.branch.name=${GITHUB_REF##*/} $KEY_OPTION -Dsonar.projectName="$PROJECT_NAME"
       env:
         SONARQUBE_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
+        PROJECT_KEY: ${{ github.repository }}
+        PROJECT_NAME: 'Hipparchus'
+        KEY_OPTION: ''
     - name: Deployment
-      if:  ( github.ref == 'refs/heads/master' ) || ( github.ref == 'refs/heads/develop' )
+      if: ( github.repository == 'Hipparchus-Math/hipparchus' ) && ( ( github.ref == 'refs/heads/master' ) || ( github.ref == 'refs/heads/develop' ) )
       run: mvn -B -f pom.xml -s .CI/maven-settings.xml deploy -Pci-deploy -DskipTests=true
       env:
         NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}


### PR DESCRIPTION
The aim of this contribution is to improve the CI process for Hipparchus' forks. Indeed, a fork must:
* push its QA report on its own SonarQube project,
* not publish its binary packages on Nexus.
I tried it successfully on my fork. Cf. the [CI run](https://github.com/sdinot/hipparchus/actions/runs/74435217) and the [dedicated project created on SonarQube](https://sonar.orekit.org/dashboard?id=sdinot%3Ahipparchus).