### PR TITLE
Add custom epsilon to EigenDecomposition and MultivariateNormalDistri…

### DIFF
--- a/hipparchus-core/src/main/java/org/hipparchus/linear/EigenDecomposition.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/EigenDecomposition.java
@@ -80,10 +80,12 @@ import org.hipparchus.util.Precision;
  * @see <a href="http://en.wikipedia.org/wiki/Eigendecomposition_of_a_matrix">Wikipedia</a>
  */
 public class EigenDecomposition {
-    /** Internally used epsilon criteria. */
-    private static final double EPSILON = 1e-12;
+    /** Default epsilon value to use for internal epsilon **/
+    private static final double DEFAULT_EPSILON = 1e-12;
     /** Maximum number of iterations accepted in the implicit QL transformation */
     private static final byte MAX_ITER = 30;
+    /** Internally used epsilon criteria. */
+    private final double epsilon;
     /** Main diagonal of the tridiagonal matrix. */
     private double[] main;
     /** Secondary diagonal of the tridiagonal matrix. */
@@ -118,8 +120,24 @@ public class EigenDecomposition {
      * @throws MathRuntimeException if the decomposition of a general matrix
      * results in a matrix with zero norm
      */
-    public EigenDecomposition(final RealMatrix matrix)
+    public EigenDecomposition(final RealMatrix matrix) {
+        this(matrix, DEFAULT_EPSILON);
+    }
+
+    /**
+     * Calculates the eigen decomposition of the given real matrix.
+     * <p>
+     * Supports decomposition of a general matrix since 3.1.
+     *
+     * @param matrix Matrix to decompose.
+     * @param epsilon Epsilon used for internal tests (e.g. is singular, eigenvalue ratio, etc.)
+     * @throws MathIllegalStateException if the algorithm fails to converge.
+     * @throws MathRuntimeException if the decomposition of a general matrix
+     * results in a matrix with zero norm
+     */
+    public EigenDecomposition(final RealMatrix matrix, double epsilon)
         throws MathRuntimeException {
+        this.epsilon = epsilon;
         final double symTol = 10 * matrix.getRowDimension() * matrix.getColumnDimension() * Precision.EPSILON;
         isSymmetric = MatrixUtils.isSymmetric(matrix, symTol);
         if (isSymmetric) {
@@ -140,6 +158,21 @@ public class EigenDecomposition {
      * @throws MathIllegalStateException if the algorithm fails to converge.
      */
     public EigenDecomposition(final double[] main, final double[] secondary) {
+        this(main, secondary, DEFAULT_EPSILON);
+    }
+
+
+    /**
+     * Calculates the eigen decomposition of the symmetric tridiagonal
+     * matrix.  The Householder matrix is assumed to be the identity matrix.
+     *
+     * @param main Main diagonal of the symmetric tridiagonal form.
+     * @param secondary Secondary of the tridiagonal form.
+     * @param epsilon Epsilon used for internal tests (e.g. is singular, eigenvalue ratio, etc.)
+     * @throws MathIllegalStateException if the algorithm fails to converge.
+     */
+    public EigenDecomposition(final double[] main, final double[] secondary, double epsilon) {
+        this.epsilon = epsilon;
         isSymmetric = true;
         this.main      = main.clone();
         this.secondary = secondary.clone();
@@ -196,15 +229,22 @@ public class EigenDecomposition {
             }
 
             for (int i = 0; i < imagEigenvalues.length; i++) {
-                if (Precision.compareTo(imagEigenvalues[i], 0.0, EPSILON) > 0) {
+                if (Precision.compareTo(imagEigenvalues[i], 0.0, epsilon) > 0) {
                     cachedD.setEntry(i, i+1, imagEigenvalues[i]);
-                } else if (Precision.compareTo(imagEigenvalues[i], 0.0, EPSILON) < 0) {
+                } else if (Precision.compareTo(imagEigenvalues[i], 0.0, epsilon) < 0) {
                     cachedD.setEntry(i, i-1, imagEigenvalues[i]);
                 }
             }
         }
         return cachedD;
     }
+
+    /**
+     * Get's the value for epsilon which is used for internal tests (e.g. is singular, eigenvalue ratio, etc.)
+     *
+     * @return the epsilon value.
+     */
+    public double getEpsilon() { return epsilon; }
 
     /**
      * Gets the transpose of the matrix V of the decomposition.
@@ -240,7 +280,7 @@ public class EigenDecomposition {
      */
     public boolean hasComplexEigenvalues() {
         for (int i = 0; i < imagEigenvalues.length; i++) {
-            if (!Precision.equals(imagEigenvalues[i], 0.0, EPSILON)) {
+            if (!Precision.equals(imagEigenvalues[i], 0.0, epsilon)) {
                 return true;
             }
         }
@@ -479,7 +519,7 @@ public class EigenDecomposition {
             for (int i = 0; i < realEigenvalues.length; ++i) {
                 // Looking for eigenvalues that are 0, where we consider anything much much smaller
                 // than the largest eigenvalue to be effectively 0.
-                if (Precision.equals(eigenvalueNorm(i) / largestEigenvalueNorm, 0, EPSILON)) {
+                if (Precision.equals(eigenvalueNorm(i) / largestEigenvalueNorm, 0, epsilon)) {
                     return false;
                 }
             }
@@ -711,7 +751,7 @@ public class EigenDecomposition {
 
         for (int i = 0; i < realEigenvalues.length; i++) {
             if (i == (realEigenvalues.length - 1) ||
-                Precision.equals(matT[i + 1][i], 0.0, norm * EPSILON)) {
+                Precision.equals(matT[i + 1][i], 0.0, norm * epsilon)) {
                 realEigenvalues[i] = matT[i][i];
             } else {
                 final double x = matT[i + 1][i + 1];
@@ -763,7 +803,7 @@ public class EigenDecomposition {
         }
 
         // we can not handle a matrix with zero norm
-        if (Precision.equals(norm, 0.0, EPSILON)) {
+        if (Precision.equals(norm, 0.0, epsilon)) {
            throw new MathRuntimeException(LocalizedCoreFormats.ZERO_NORM);
         }
 
@@ -787,7 +827,7 @@ public class EigenDecomposition {
                     for (int j = l; j <= idx; j++) {
                         r += matrixT[i][j] * matrixT[j][idx];
                     }
-                    if (Precision.compareTo(imagEigenvalues[i], 0.0, EPSILON) < 0) {
+                    if (Precision.compareTo(imagEigenvalues[i], 0.0, epsilon) < 0) {
                         z = w;
                         s = r;
                     } else {
@@ -849,7 +889,7 @@ public class EigenDecomposition {
                     }
                     double w = matrixT[i][i] - p;
 
-                    if (Precision.compareTo(imagEigenvalues[i], 0.0, EPSILON) < 0) {
+                    if (Precision.compareTo(imagEigenvalues[i], 0.0, epsilon) < 0) {
                         z = w;
                         r = ra;
                         s = sa;

--- a/hipparchus-core/src/test/java/org/hipparchus/distribution/multivariate/MultivariateNormalDistributionTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/distribution/multivariate/MultivariateNormalDistributionTest.java
@@ -28,6 +28,7 @@ import org.hipparchus.UnitTestUtils;
 import org.hipparchus.distribution.continuous.NormalDistribution;
 import org.hipparchus.linear.Array2DRowRealMatrix;
 import org.hipparchus.linear.RealMatrix;
+import org.hipparchus.util.Precision;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -157,4 +158,22 @@ public class MultivariateNormalDistributionTest {
             Assert.assertEquals(uni.density(v), multi.density(new double[] { v }), tol);
         }
     }
+
+    /**
+     * Test getting/setting custom singularMatrixTolerance
+     */
+    @Test
+    public void testGetSingularMatrixTolerance() {
+        final double[] mu = { -1.5 };
+        final double[][] sigma = { { 1 } };
+
+        final double tolerance1 = 1e-2;
+        final MultivariateNormalDistribution mvd1 = new MultivariateNormalDistribution(mu, sigma, tolerance1);
+        Assert.assertEquals(tolerance1, mvd1.getSingularMatrixCheckTolerance(), Precision.EPSILON);
+
+        final double tolerance2 = 1e-3;
+        final MultivariateNormalDistribution mvd2 = new MultivariateNormalDistribution(mu, sigma, tolerance1);
+        Assert.assertEquals(tolerance1, mvd1.getSingularMatrixCheckTolerance(), Precision.EPSILON);
+    }
+
 }

--- a/hipparchus-core/src/test/java/org/hipparchus/linear/EigenDecompositionTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/linear/EigenDecompositionTest.java
@@ -659,6 +659,28 @@ public class EigenDecompositionTest {
     }
 
     /**
+     * Verifies that a custom epsilon value is used when testing for singular
+     */
+    @Test
+    public void testCustomEpsilon() {
+        RealMatrix matrix = MatrixUtils.createRealMatrix(new double[][] {
+            {1.76208738E-13,	-9.37625373E-13,	-1.94760551E-12,	-2.56572222E-11,	-7.30093964E-11,	-1.98340808E-09},
+            {-9.37625373E-13,	5.00812620E-12,	1.06017205E-11,	1.40431472E-10,	3.62452521E-10,	1.05830167E-08},
+            {-1.94760551E-12,	1.06017205E-11,	3.15658331E-11,	2.32155752E-09,	-1.53067748E-09,	2.23110293E-08},
+            {-2.56572222E-11,	1.40431472E-10,	2.32155752E-09,	8.81161492E-07,	-8.70304198E-07,	2.93564832E-07},
+            {-7.30093964E-11,	3.62452521E-10,	-1.53067748E-09,	-8.70304198E-07,	9.42413982E-07,	7.81029359E-07},
+            {-1.98340808E-09,	1.05830167E-08,	2.23110293E-08,	2.93564832E-07,	7.81029359E-07,	2.23721205E-05}
+        });
+
+        final EigenDecomposition defaultEd = new EigenDecomposition(matrix);
+        Assert.assertFalse(defaultEd.getSolver().isNonSingular());
+
+        final double customEpsilon = 1e-20;
+        final EigenDecomposition customEd = new EigenDecomposition(matrix, customEpsilon);
+        Assert.assertTrue(customEd.getSolver().isNonSingular());
+    }
+
+    /**
      * Verifies that the given EigenDecomposition has eigenvalues equivalent to
      * the targetValues, ignoring the order of the values and allowing
      * values to differ by tolerance.


### PR DESCRIPTION
Adds the custom epsilon/tolerance capability to these classes for Issue #100 . This change adds new constructions to set the tolerance values on both classes (MultivariateNormDistribution uses EigenDecomposition). There are tests to confirm that the variable is properly set and/or used in the computations. The current default value of 1e-12 is maintained for potential backward compatibility reasons.