### PR TITLE
Change Highlight.js CDN

### DIFF
--- a/hipparchus-clustering/src/site/site.xml
+++ b/hipparchus-clustering/src/site/site.xml
@@ -59,8 +59,8 @@
 
   <body>
     <head>
-      <link rel="stylesheet" href="https://yandex.st/highlightjs/7.5/styles/default.min.css"/>
-      <script src="https://yandex.st/highlightjs/7.5/highlight.min.js"></script>
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/styles/default.min.css"/>
+      <script src="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/highlight.min.js"></script>
     </head>
 
     <menu name="Hipparchus">

--- a/hipparchus-core/src/site/site.xml
+++ b/hipparchus-core/src/site/site.xml
@@ -63,8 +63,8 @@
 
   <body>
     <head>
-      <link rel="stylesheet" href="https://yandex.st/highlightjs/7.5/styles/default.min.css"/>
-      <script src="https://yandex.st/highlightjs/7.5/highlight.min.js"></script>
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/styles/default.min.css"/>
+      <script src="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/highlight.min.js"></script>
     </head>
 
     <menu name="Hipparchus">

--- a/hipparchus-fft/src/site/site.xml
+++ b/hipparchus-fft/src/site/site.xml
@@ -59,8 +59,8 @@
 
   <body>
     <head>
-      <link rel="stylesheet" href="https://yandex.st/highlightjs/7.5/styles/default.min.css"/>
-      <script src="https://yandex.st/highlightjs/7.5/highlight.min.js"></script>
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/styles/default.min.css"/>
+      <script src="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/highlight.min.js"></script>
     </head>
 
     <menu name="Hipparchus">

--- a/hipparchus-filtering/src/site/site.xml
+++ b/hipparchus-filtering/src/site/site.xml
@@ -59,8 +59,8 @@
 
   <body>
     <head>
-      <link rel="stylesheet" href="https://yandex.st/highlightjs/7.5/styles/default.min.css"/>
-      <script src="https://yandex.st/highlightjs/7.5/highlight.min.js"></script>
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/styles/default.min.css"/>
+      <script src="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/highlight.min.js"></script>
     </head>
 
     <menu name="Hipparchus">

--- a/hipparchus-fitting/src/site/site.xml
+++ b/hipparchus-fitting/src/site/site.xml
@@ -59,8 +59,8 @@
 
   <body>
     <head>
-      <link rel="stylesheet" href="https://yandex.st/highlightjs/7.5/styles/default.min.css"/>
-      <script src="https://yandex.st/highlightjs/7.5/highlight.min.js"></script>
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/styles/default.min.css"/>
+      <script src="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/highlight.min.js"></script>
     </head>
 
     <menu name="Hipparchus">

--- a/hipparchus-geometry/src/site/site.xml
+++ b/hipparchus-geometry/src/site/site.xml
@@ -59,8 +59,8 @@
 
   <body>
     <head>
-      <link rel="stylesheet" href="https://yandex.st/highlightjs/7.5/styles/default.min.css"/>
-      <script src="https://yandex.st/highlightjs/7.5/highlight.min.js"></script>
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/styles/default.min.css"/>
+      <script src="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/highlight.min.js"></script>
     </head>
 
     <menu name="Hipparchus">

--- a/hipparchus-migration/src/site/site.xml
+++ b/hipparchus-migration/src/site/site.xml
@@ -59,8 +59,8 @@
 
   <body>
     <head>
-      <link rel="stylesheet" href="https://yandex.st/highlightjs/7.5/styles/default.min.css"/>
-      <script src="https://yandex.st/highlightjs/7.5/highlight.min.js"></script>
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/styles/default.min.css"/>
+      <script src="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/highlight.min.js"></script>
     </head>
 
     <menu name="Hipparchus">

--- a/hipparchus-ode/src/site/site.xml
+++ b/hipparchus-ode/src/site/site.xml
@@ -59,8 +59,8 @@
 
   <body>
     <head>
-      <link rel="stylesheet" href="https://yandex.st/highlightjs/7.5/styles/default.min.css"/>
-      <script src="https://yandex.st/highlightjs/7.5/highlight.min.js"></script>
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/styles/default.min.css"/>
+      <script src="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/highlight.min.js"></script>
     </head>
 
     <menu name="Hipparchus">

--- a/hipparchus-optim/src/site/site.xml
+++ b/hipparchus-optim/src/site/site.xml
@@ -59,8 +59,8 @@
 
   <body>
     <head>
-      <link rel="stylesheet" href="https://yandex.st/highlightjs/7.5/styles/default.min.css"/>
-      <script src="https://yandex.st/highlightjs/7.5/highlight.min.js"></script>
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/styles/default.min.css"/>
+      <script src="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/highlight.min.js"></script>
     </head>
 
     <menu name="Hipparchus">

--- a/hipparchus-samples/src/site/site.xml
+++ b/hipparchus-samples/src/site/site.xml
@@ -59,8 +59,8 @@
 
   <body>
     <head>
-      <link rel="stylesheet" href="https://yandex.st/highlightjs/7.5/styles/default.min.css"/>
-      <script src="https://yandex.st/highlightjs/7.5/highlight.min.js"></script>
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/styles/default.min.css"/>
+      <script src="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/highlight.min.js"></script>
     </head>
 
     <menu name="Hipparchus">

--- a/hipparchus-stat/src/site/site.xml
+++ b/hipparchus-stat/src/site/site.xml
@@ -59,8 +59,8 @@
 
   <body>
     <head>
-      <link rel="stylesheet" href="https://yandex.st/highlightjs/7.5/styles/default.min.css"/>
-      <script src="https://yandex.st/highlightjs/7.5/highlight.min.js"></script>
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/styles/default.min.css"/>
+      <script src="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/highlight.min.js"></script>
     </head>
 
     <menu name="Hipparchus">

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -79,8 +79,8 @@
 
   <body>
     <head>
-      <link rel="stylesheet" href="https://yandex.st/highlightjs/7.5/styles/default.min.css"/>
-      <script src="https://yandex.st/highlightjs/7.5/highlight.min.js"></script>
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/styles/default.min.css"/>
+      <script src="https://unpkg.com/@highlightjs/cdn-assets@11.2.0/highlight.min.js"></script>
     </head>
 
     <menu name="Hipparchus">


### PR DESCRIPTION
This commit results from the following topic on Discourse:

[Can we remove yandex?](https://forum.orekit.org/t/can-we-remove-yandex/1315)

I finally opted for the CDN of unpkg.com. This CDN has an excellent reputation and it is more and more used.