### PR TITLE
Add more info to failed event detection

### DIFF
--- a/hipparchus-core/src/changes/changes.xml
+++ b/hipparchus-core/src/changes/changes.xml
@@ -49,6 +49,13 @@ If the output is not quite correct, check for invisible trailing spaces!
     <title>Hipparchus Core Release Notes</title>
   </properties>
   <body>
+    <release version="2.1" date="TBD" description="TBD">
+      <action dev="evan" type="update" due-to="Anne-Laure Lugan">
+        Add more information to exception when event detection root finding fails.
+        Backward incompatible in that it changes the type of exception to
+        MathRuntimeException.
+      </action>
+    </release>
     <release version="2.0" date="2021-08-07" description="This is a major release. The main changes
     are replacement of RealFieldElement by CalculusFieldElement interface, many improvements in Complex
     to fully implement CalculusFieldElement with correct branch cuts so complex numbers can be used in

--- a/hipparchus-ode/src/main/java/org/hipparchus/ode/LocalizedODEFormats.java
+++ b/hipparchus-ode/src/main/java/org/hipparchus/ode/LocalizedODEFormats.java
@@ -55,7 +55,8 @@ public enum LocalizedODEFormats implements Localizable {
     TOO_SMALL_INTEGRATION_INTERVAL("too small integration interval: length = {0}"),
     UNKNOWN_PARAMETER("unknown parameter {0}"),
     UNMATCHED_ODE_IN_EXPANDED_SET("ode does not match the main ode set in the extended set"),
-    NAN_APPEARING_DURING_INTEGRATION("NaN appears during integration near time {0}");
+    NAN_APPEARING_DURING_INTEGRATION("NaN appears during integration near time {0}"),
+    FIND_ROOT("{0} failed to find root between {1,number,0.0##############E0} (g={2,number,0.0##############E0}) and {3,number,0.0##############E0} (g={4,number,0.0##############E0})");
 
     // CHECKSTYLE: resume JavadocVariable
     // CHECKSTYLE: resume MultipleVariableDeclarations

--- a/hipparchus-ode/src/main/java/org/hipparchus/ode/events/EventState.java
+++ b/hipparchus-ode/src/main/java/org/hipparchus/ode/events/EventState.java
@@ -28,6 +28,7 @@ import org.hipparchus.analysis.solvers.BracketedUnivariateSolver.Interval;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.MathIllegalStateException;
 import org.hipparchus.exception.MathRuntimeException;
+import org.hipparchus.ode.LocalizedODEFormats;
 import org.hipparchus.ode.ODEState;
 import org.hipparchus.ode.ODEStateAndDerivative;
 import org.hipparchus.ode.sampling.ODEStateInterpolator;
@@ -334,19 +335,33 @@ public class EventState implements EventHandlerConfiguration {
             } else {
                 // both non-zero, the usual case, use a root finder.
                 if (forward) {
-                    final Interval interval =
-                            solver.solveInterval(maxIterationCount, f, loopT, tb);
-                    beforeRootT = interval.getLeftAbscissa();
-                    beforeRootG = interval.getLeftValue();
-                    afterRootT = interval.getRightAbscissa();
-                    afterRootG = interval.getRightValue();
-                } else {
-                    final Interval interval =
-                            solver.solveInterval(maxIterationCount, f, tb, loopT);
-                    beforeRootT = interval.getRightAbscissa();
-                    beforeRootG = interval.getRightValue();
-                    afterRootT = interval.getLeftAbscissa();
-                    afterRootG = interval.getLeftValue();
+                    try {
+                        final Interval interval =
+                                solver.solveInterval(maxIterationCount, f, loopT, tb);
+                        beforeRootT = interval.getLeftAbscissa();
+                        beforeRootG = interval.getLeftValue();
+                        afterRootT = interval.getRightAbscissa();
+                        afterRootG = interval.getRightValue();
+                        // CHECKSTYLE: stop IllegalCatch check
+                    } catch (RuntimeException e) {
+                        // CHECKSTYLE: resume IllegalCatch check
+                        throw new MathRuntimeException(e, LocalizedODEFormats.FIND_ROOT,
+                                handler, loopT, loopG, tb, gb);
+                    }
+            } else {
+                    try {
+                        final Interval interval =
+                                solver.solveInterval(maxIterationCount, f, tb, loopT);
+                        beforeRootT = interval.getRightAbscissa();
+                        beforeRootG = interval.getRightValue();
+                        afterRootT = interval.getLeftAbscissa();
+                        afterRootG = interval.getLeftValue();
+                        // CHECKSTYLE: stop IllegalCatch check
+                    } catch (RuntimeException e) {
+                        // CHECKSTYLE: resume IllegalCatch check
+                        throw new MathRuntimeException(e, LocalizedODEFormats.FIND_ROOT,
+                                handler, loopT, loopG, tb, gb);
+                    }
                 }
             }
             // tolerance is set to less than 1 ulp

--- a/hipparchus-ode/src/main/java/org/hipparchus/ode/events/FieldEventState.java
+++ b/hipparchus-ode/src/main/java/org/hipparchus/ode/events/FieldEventState.java
@@ -31,6 +31,7 @@ import org.hipparchus.exception.MathIllegalStateException;
 import org.hipparchus.exception.MathRuntimeException;
 import org.hipparchus.ode.FieldODEState;
 import org.hipparchus.ode.FieldODEStateAndDerivative;
+import org.hipparchus.ode.LocalizedODEFormats;
 import org.hipparchus.ode.sampling.FieldODEStateInterpolator;
 import org.hipparchus.util.FastMath;
 
@@ -355,19 +356,33 @@ public class FieldEventState<T extends CalculusFieldElement<T>> implements Field
             } else {
                 // both non-zero, the usual case, use a root finder.
                 if (forward) {
-                    final Interval<T> interval =
-                            solver.solveInterval(maxIterationCount, f, loopT, tb);
-                    beforeRootT = interval.getLeftAbscissa();
-                    beforeRootG = interval.getLeftValue();
-                    afterRootT = interval.getRightAbscissa();
-                    afterRootG = interval.getRightValue();
+                    try {
+                        final Interval<T> interval =
+                                solver.solveInterval(maxIterationCount, f, loopT, tb);
+                        beforeRootT = interval.getLeftAbscissa();
+                        beforeRootG = interval.getLeftValue();
+                        afterRootT = interval.getRightAbscissa();
+                        afterRootG = interval.getRightValue();
+                        // CHECKSTYLE: stop IllegalCatch check
+                    } catch (RuntimeException e) {
+                        // CHECKSTYLE: resume IllegalCatch check
+                        throw new MathRuntimeException(e, LocalizedODEFormats.FIND_ROOT,
+                                handler, loopT, loopG, tb, gb);
+                    }
                 } else {
-                    final Interval<T> interval =
-                            solver.solveInterval(maxIterationCount, f, tb, loopT);
-                    beforeRootT = interval.getRightAbscissa();
-                    beforeRootG = interval.getRightValue();
-                    afterRootT = interval.getLeftAbscissa();
-                    afterRootG = interval.getLeftValue();
+                    try {
+                        final Interval<T> interval =
+                                solver.solveInterval(maxIterationCount, f, tb, loopT);
+                        beforeRootT = interval.getRightAbscissa();
+                        beforeRootG = interval.getRightValue();
+                        afterRootT = interval.getLeftAbscissa();
+                        afterRootG = interval.getLeftValue();
+                        // CHECKSTYLE: stop IllegalCatch check
+                    } catch (RuntimeException e) {
+                        // CHECKSTYLE: resume IllegalCatch check
+                        throw new MathRuntimeException(e, LocalizedODEFormats.FIND_ROOT,
+                                handler, loopT, loopG, tb, gb);
+                    }
                 }
             }
             // tolerance is set to less than 1 ulp

--- a/hipparchus-ode/src/main/resources/assets/org/hipparchus/ode/LocalizedODEFormats_fr.utf8
+++ b/hipparchus-ode/src/main/resources/assets/org/hipparchus/ode/LocalizedODEFormats_fr.utf8
@@ -25,3 +25,5 @@ TOO_SMALL_INTEGRATION_INTERVAL = intervalle d''intégration trop petit : {0}
 UNKNOWN_PARAMETER = paramètre {0} inconnu
 UNMATCHED_ODE_IN_EXPANDED_SET = l''équation différentielle ne correspond pas à l''équation principale du jeu étendu
 NAN_APPEARING_DURING_INTEGRATION = apparition de NaN pendant l''intégration aux environs du temps {0}
+#  {0} failed to find root between {1,number,0.0##############E0} (g={2,number,0.0##############E0}) and {3,number,0.0##############E0} (g={4,number,0.0##############E0})
+FIND_ROOT = <MISSING TRANSLATION>

--- a/hipparchus-ode/src/test/java/org/hipparchus/ode/LocalizedODEFormatsTest.java
+++ b/hipparchus-ode/src/test/java/org/hipparchus/ode/LocalizedODEFormatsTest.java
@@ -32,7 +32,7 @@ public class LocalizedODEFormatsTest extends LocalizedFormatsAbstractTest {
 
     @Override
     protected int getExpectedNumber() {
-        return 9;
+        return 10;
     }
 
 }

--- a/hipparchus-ode/src/test/java/org/hipparchus/ode/nonstiff/EmbeddedRungeKuttaFieldIntegratorAbstractTest.java
+++ b/hipparchus-ode/src/test/java/org/hipparchus/ode/nonstiff/EmbeddedRungeKuttaFieldIntegratorAbstractTest.java
@@ -22,7 +22,10 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.hipparchus.CalculusFieldElement;
 import org.hipparchus.Field;
 import org.hipparchus.analysis.differentiation.DSFactory;
@@ -30,6 +33,7 @@ import org.hipparchus.analysis.differentiation.DerivativeStructure;
 import org.hipparchus.analysis.solvers.FieldBracketingNthOrderBrentSolver;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.MathIllegalStateException;
+import org.hipparchus.exception.MathRuntimeException;
 import org.hipparchus.ode.FieldExpandableODE;
 import org.hipparchus.ode.FieldODEIntegrator;
 import org.hipparchus.ode.FieldODEState;
@@ -338,8 +342,13 @@ public abstract class EmbeddedRungeKuttaFieldIntegratorAbstractTest {
         try {
             integ.integrate(new FieldExpandableODE<T>(pb), pb.getInitialState(), pb.getFinalTime());
             Assert.fail("an exception should have been thrown");
-        } catch (MathIllegalStateException mcee) {
+        } catch (MathRuntimeException e) {
             // Expected.
+            MatcherAssert.assertThat(e.getMessage(Locale.US),
+                    CoreMatchers.containsString("failed to find root between"));
+            MathIllegalStateException cause = (MathIllegalStateException) e.getCause();
+            MatcherAssert.assertThat(cause.getMessage(Locale.US),
+                    CoreMatchers.containsString("maximal count"));
         }
 
     }

--- a/hipparchus-ode/src/test/java/org/hipparchus/ode/nonstiff/EmbeddedRungeKuttaIntegratorAbstractTest.java
+++ b/hipparchus-ode/src/test/java/org/hipparchus/ode/nonstiff/EmbeddedRungeKuttaIntegratorAbstractTest.java
@@ -23,10 +23,14 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.hipparchus.analysis.solvers.BracketingNthOrderBrentSolver;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.MathIllegalStateException;
+import org.hipparchus.exception.MathRuntimeException;
 import org.hipparchus.ode.ExpandableODE;
 import org.hipparchus.ode.LocalizedODEFormats;
 import org.hipparchus.ode.ODEIntegrator;
@@ -270,8 +274,13 @@ public abstract class EmbeddedRungeKuttaIntegratorAbstractTest {
         try {
             integ.integrate(new ExpandableODE(pb), pb.getInitialState(), pb.getFinalTime());
             Assert.fail("an exception should have been thrown");
-        } catch (MathIllegalStateException mcee) {
+        } catch (MathRuntimeException e) {
             // Expected.
+            MatcherAssert.assertThat(e.getMessage(Locale.US),
+                    CoreMatchers.containsString("failed to find root between"));
+            MathIllegalStateException cause = (MathIllegalStateException) e.getCause();
+            MatcherAssert.assertThat(cause.getMessage(Locale.US),
+                    CoreMatchers.containsString("maximal count"));
         }
 
     }


### PR DESCRIPTION
Patterned after similar changes in Orekit due to Anne-Laure Lugan.
Changes type of exception thrown to MathRuntimeException. Addes t,g
values at start and end of interval passed to the root finder.

Could achieve a similar effect without a backwards incompatibility by using `addsuppresed(...)` and re-throwing the existing exception instead of throwing a new exception. Implementation would be different from Orekit's then.