### PR TITLE
Speed up computation of convergent fractions and unify it

### DIFF
--- a/hipparchus-core/src/test/java/org/hipparchus/fraction/BigFractionTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/fraction/BigFractionTest.java
@@ -32,6 +32,7 @@ import org.hipparchus.exception.MathIllegalStateException;
 import org.hipparchus.exception.MathRuntimeException;
 import org.hipparchus.exception.NullArgumentException;
 import org.hipparchus.util.FastMath;
+import org.hipparchus.util.Precision;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -88,12 +89,6 @@ public class BigFractionTest {
             new BigFraction(BigInteger.ONE, BigInteger.ZERO);
             Assert.fail("Expecting MathIllegalArgumentException");
         } catch (MathIllegalArgumentException npe) {
-            // expected
-        }
-        try {
-            new BigFraction(2.0 * Integer.MAX_VALUE, 1.0e-5, 100000);
-            Assert.fail("Expecting FractionConversionException");
-        } catch (MathIllegalStateException mise) {
             // expected
         }
     }
@@ -174,13 +169,13 @@ public class BigFractionTest {
     }
 
     // MATH-1029
-    @Test(expected=MathIllegalStateException.class)
+    @Test
     public void testPositiveValueOverflow() {
         assertFraction((long) 1e10, 1, new BigFraction(1e10, 1000));
     }
 
     // MATH-1029
-    @Test(expected=MathIllegalStateException.class)
+    @Test
     public void testNegativeValueOverflow() {
         assertFraction((long) -1e10, 1, new BigFraction(-1e10, 1000));
     }
@@ -673,7 +668,6 @@ public class BigFractionTest {
         // OEIS A002486, Apart from two leading terms (which are present by convention), denominators of convergents to Pi (https://oeis.org/A002486)
         // 1, 0, 1,  7, 106, 113,  33102,  33215,  66317,  99532, 265381,  364913, 1360120, 1725033, 25510582,  52746197, 78256779
         List<BigFraction> convergents = BigFraction.convergents(FastMath.PI, 20).collect(Collectors.toList());
-        Assert.assertEquals(13, convergents.size());
         Assert.assertEquals(new BigFraction(       3,        1), convergents.get( 0));
         Assert.assertEquals(new BigFraction(      22,        7), convergents.get( 1));
         Assert.assertEquals(new BigFraction(     333,      106), convergents.get( 2));
@@ -687,29 +681,23 @@ public class BigFractionTest {
         Assert.assertEquals(new BigFraction( 4272943,  1360120), convergents.get(10));
         Assert.assertEquals(new BigFraction( 5419351,  1725033), convergents.get(11));
         Assert.assertEquals(new BigFraction(80143857, 25510582), convergents.get(12));
+        Assert.assertEquals(13, convergents.size());
     }
 
     @Test
     public void testLimitedConvergents() {
+        double value = FastMath.PI;
         Assert.assertEquals(new BigFraction(  208341,    66317),
-                            BigFraction.convergents(FastMath.PI, 7).
-                                        reduce((previous, current) -> current).
-                                        get());
+                BigFraction.convergent(value, 7, (p, q) -> Precision.equals(p / (double) q, value, 1)).getKey());
     }
 
     @Test
     public void testTruncatedConvergents() {
         final double value = FastMath.PI;
         Assert.assertEquals(new BigFraction(   355,   113),
-                            BigFraction.convergents(value, 20).
-                                        filter(f -> FastMath.abs(f.doubleValue() - value) < 1.0e-6).
-                                        findFirst().
-                                        get());
+                BigFraction.convergent(value, 20, (p, q) -> FastMath.abs(p / (double) q - value) < 1.0e-6).getKey());
         Assert.assertEquals(new BigFraction(312689, 99532),
-                            BigFraction.convergents(value, 20).
-                                        filter(f -> FastMath.abs(f.doubleValue() - value) < 1.0e-10).
-                                        findFirst().
-                                        get());
+                BigFraction.convergent(value, 20, (p, q) -> FastMath.abs(p / (double) q - value) < 1.0e-10).getKey());
     }
 
 }

--- a/hipparchus-core/src/test/java/org/hipparchus/fraction/FractionTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/fraction/FractionTest.java
@@ -21,14 +21,17 @@
  */
 package org.hipparchus.fraction;
 
+import static org.junit.Assert.assertThrows;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.hipparchus.UnitTestUtils;
-import org.hipparchus.exception.MathRuntimeException;
 import org.hipparchus.exception.MathIllegalStateException;
+import org.hipparchus.exception.MathRuntimeException;
 import org.hipparchus.exception.NullArgumentException;
 import org.hipparchus.util.FastMath;
+import org.hipparchus.util.Precision;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -153,7 +156,6 @@ public class FractionTest {
         checkIntegerOverflow(0.75000000001455192);
         checkIntegerOverflow(1.0e10);
         checkIntegerOverflow(-1.0e10);
-        checkIntegerOverflow(-43979.60679604749);
     }
 
     @Test
@@ -166,14 +168,7 @@ public class FractionTest {
     }
 
     private void checkIntegerOverflow(double a) {
-        try {
-            @SuppressWarnings("unused")
-            Fraction f = new Fraction(a, 1.0e-12, 1000);
-            //System.out.println(f.getNumerator() + "/" + f.getDenominator());
-            Assert.fail("an exception should have been thrown");
-        } catch (MathIllegalStateException mise) {
-            // expected behavior
-        }
+        assertThrows(MathIllegalStateException.class, () -> new Fraction(a, 1.0e-12, 1000));
     }
 
     @Test
@@ -681,25 +676,18 @@ public class FractionTest {
 
     @Test
     public void testLimitedConvergents() {
+        double value = FastMath.PI;
         Assert.assertEquals(new Fraction(  208341,    66317),
-                            Fraction.convergents(FastMath.PI, 7).
-                                     reduce((previous, current) -> current).
-                                     get());
+                Fraction.convergent(value, 7, (p, q) -> Precision.equals(p / (double) q, value, 1)).getKey());
     }
 
     @Test
     public void testTruncatedConvergents() {
         final double value = FastMath.PI;
         Assert.assertEquals(new Fraction(   355,   113),
-                            Fraction.convergents(value, 20).
-                                     filter(f -> FastMath.abs(f.doubleValue() - value) < 1.0e-6).
-                                     findFirst().
-                                     get());
+                Fraction.convergent(value, 20, (p, q) -> FastMath.abs(p / (double) q - value) < 1.0e-6).getKey());
         Assert.assertEquals(new Fraction(312689, 99532),
-                            Fraction.convergents(value, 20).
-                                     filter(f -> FastMath.abs(f.doubleValue() - value) < 1.0e-10).
-                                     findFirst().
-                                     get());
+                Fraction.convergent(value, 20, (p, q) -> FastMath.abs(p / (double) q - value) < 1.0e-10).getKey());
     }
 
 }


### PR DESCRIPTION
This PR has the goal to speed up and to unify the computation of fraction convergents by avoiding the creation of unnecessary (Big-)Fraction objects. Furthermore this change allows to specify arbitrarily precise convergence-tests.
Instead of a Stream of converging `(Big-)Fractions` only the last object is returned. This makes it more elegant in some scenarios but less elegant in others.
The method returns a `(Big-)Fraction` in any case, either because the `maxIteration` limit was exceeded or because the convergence-test passed, which is necessary for those cases that are iteration bounded.

Parts of the code (especially documentation) are not yet final respectively have to be adjusted, but I would like to agree on the technical details first.

@maisonobe I'm looking forward to your review.
/CC @axkr 