### PR TITLE
Make equals consistent with IEEE754 concerning NaN coordinates.

### DIFF
--- a/hipparchus-geometry/src/changes/changes.xml
+++ b/hipparchus-geometry/src/changes/changes.xml
@@ -49,6 +49,13 @@ If the output is not quite correct, check for invisible trailing spaces!
     <title>Hipparchus Geometry Release Notes</title>
   </properties>
   <body>
+    <release version="3.0" date="TBD" description="TBD">
+      <action dev="luc" type="update">
+        Make equals consistent with IEEE754 concerning NaN coordinates
+        for S1Point, S2Point, Vector1D, Vector2D and Vector3D (i.e. when
+        there is a NaN anywhere, equals returns false).
+      </action>
+    </release>
     <release version="2.0" date="2021-08-07" description="This is a major release. The only changes are
     removal of deprecated methods.">
       <action dev="luc" type="fix" issue="issues/121">

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/oned/Vector1D.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/oned/Vector1D.java
@@ -305,13 +305,47 @@ public class Vector1D implements Vector<Euclidean1D> {
      * Test for the equality of two 1D vectors.
      * <p>
      * If all coordinates of two 1D vectors are exactly the same, and none are
-     * <code>Double.NaN</code>, the two 1D vectors are considered to be equal.
+     * {@code Double.NaN}, the two 1D vectors are considered to be equal.
      * </p>
      * <p>
-     * <code>NaN</code> coordinates are considered to affect globally the vector
+     * {@code NaN} coordinates are considered to affect globally the vector
      * and be equals to each other - i.e, if either (or all) coordinates of the
-     * 1D vector are equal to <code>Double.NaN</code>, the 1D vector is equal to
+     * 1D vector are equal to {@code Double.NaN}, the 1D vector is equal to
      * {@link #NaN}.
+     * </p>
+     *
+     * @param other Object to test for equality to this
+     * @return true if two 1D vector objects are equal, false if
+     *         object is null, not an instance of Vector1D, or
+     *         not equal to this Vector1D instance
+     * @since 3.0
+     */
+    public boolean equalsIncludingNaN(Object other) {
+
+        if (this == other) {
+            return true;
+        }
+
+        if (other instanceof Vector1D) {
+            final Vector1D rhs = (Vector1D) other;
+            return x == rhs.x || isNaN() && rhs.isNaN();
+        }
+
+        return false;
+
+    }
+
+    /**
+     * Test for the equality of two 1D vectors.
+     * <p>
+     * If all coordinates of two 1D vectors are exactly the same, and none are
+     * {@code NaN}, the two 1D vectors are considered to be equal.
+     * </p>
+     * <p>
+     * In compliance with IEEE754 handling, if any coordinates of any of the
+     * two vectors are {@code NaN}, then the vectors are considered different.
+     * This implies that {@link #NaN Vector1D.NaN}.equals({@link #NaN Vector1D.NaN})
+     * returns {@code false} despite the instance is checked against itself.
      * </p>
      *
      * @param other Object to test for equality to this
@@ -323,19 +357,17 @@ public class Vector1D implements Vector<Euclidean1D> {
     @Override
     public boolean equals(Object other) {
 
-        if (this == other) {
+        if (this == other && !isNaN()) {
             return true;
         }
 
         if (other instanceof Vector1D) {
-            final Vector1D rhs = (Vector1D)other;
-            if (rhs.isNaN()) {
-                return this.isNaN();
-            }
-
+            final Vector1D rhs = (Vector1D) other;
             return x == rhs.x;
         }
+
         return false;
+
     }
 
     /**

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/threed/Vector3D.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/threed/Vector3D.java
@@ -416,13 +416,48 @@ public class Vector3D implements Serializable, Vector<Euclidean3D> {
      * Test for the equality of two 3D vectors.
      * <p>
      * If all coordinates of two 3D vectors are exactly the same, and none are
-     * <code>Double.NaN</code>, the two 3D vectors are considered to be equal.
+     * {@code Double.NaN}, the two 3D vectors are considered to be equal.
      * </p>
      * <p>
-     * <code>NaN</code> coordinates are considered to affect globally the vector
+     * {@code NaN} coordinates are considered to affect globally the vector
      * and be equals to each other - i.e, if either (or all) coordinates of the
-     * 3D vector are equal to <code>Double.NaN</code>, the 3D vector is equal to
+     * 3D vector are equal to {@code Double.NaN}, the 3D vector is equal to
      * {@link #NaN}.
+     * </p>
+     *
+     * @param other Object to test for equality to this
+     * @return true if two 3D vector objects are equal, false if
+     *         object is null, not an instance of Vector3D, or
+     *         not equal to this Vector3D instance
+     *
+     * @since 3.0
+     */
+    public boolean equalsIncludingNaN(Object other) {
+
+        if (this == other) {
+            return true;
+        }
+
+        if (other instanceof Vector3D) {
+            final Vector3D rhs = (Vector3D)other;
+            return x == rhs.x && y == rhs.y && z == rhs.z || isNaN() && rhs.isNaN();
+        }
+
+        return false;
+
+    }
+
+    /**
+     * Test for the equality of two 3D vectors.
+     * <p>
+     * If all coordinates of two 3D vectors are exactly the same, and none are
+     * {@code NaN}, the two 3D vectors are considered to be equal.
+     * </p>
+     * <p>
+     * In compliance with IEEE754 handling, if any coordinates of any of the
+     * two vectors are {@code NaN}, then the vectors are considered different.
+     * This implies that {@link #NaN Vector3D.NaN}.equals({@link #NaN Vector3D.NaN})
+     * returns {@code false} despite the instance is checked against itself.
      * </p>
      *
      * @param other Object to test for equality to this
@@ -434,19 +469,17 @@ public class Vector3D implements Serializable, Vector<Euclidean3D> {
     @Override
     public boolean equals(Object other) {
 
-        if (this == other) {
+        if (this == other && !isNaN()) {
             return true;
         }
 
         if (other instanceof Vector3D) {
-            final Vector3D rhs = (Vector3D)other;
-            if (rhs.isNaN()) {
-                return this.isNaN();
-            }
-
-            return (x == rhs.x) && (y == rhs.y) && (z == rhs.z);
+            final Vector3D rhs = (Vector3D) other;
+            return x == rhs.x && y == rhs.y && z == rhs.z;
         }
+
         return false;
+
     }
 
     /**

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/twod/Vector2D.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/twod/Vector2D.java
@@ -466,13 +466,47 @@ public class Vector2D implements Vector<Euclidean2D> {
      * Test for the equality of two 2D vectors.
      * <p>
      * If all coordinates of two 2D vectors are exactly the same, and none are
-     * <code>Double.NaN</code>, the two 2D vectors are considered to be equal.
+     * {@code Double.NaN}, the two 2D vectors are considered to be equal.
      * </p>
      * <p>
-     * <code>NaN</code> coordinates are considered to affect globally the vector
+     * {@code NaN} coordinates are considered to affect globally the vector
      * and be equals to each other - i.e, if either (or all) coordinates of the
-     * 2D vector are equal to <code>Double.NaN</code>, the 2D vector is equal to
+     * 2D vector are equal to {@code Double.NaN}, the 2D vector is equal to
      * {@link #NaN}.
+     * </p>
+     *
+     * @param other Object to test for equality to this
+     * @return true if two 2D vector objects are equal, false if
+     *         object is null, not an instance of Vector2D, or
+     *         not equal to this Vector2D instance
+     * @since 3.0
+     */
+    public boolean equalsIncludingNaN(Object other) {
+
+        if (this == other) {
+            return true;
+        }
+
+        if (other instanceof Vector2D) {
+            final Vector2D rhs = (Vector2D)other;
+            return x == rhs.x && y == rhs.y || isNaN() && rhs.isNaN();
+        }
+
+        return false;
+
+    }
+
+    /**
+     * Test for the equality of two 2D vectors.
+     * <p>
+     * If all coordinates of two 2D vectors are exactly the same, and none are
+     * {@code NaN}, the two 2D vectors are considered to be equal.
+     * </p>
+     * <p>
+     * In compliance with IEEE754 handling, if any coordinates of any of the
+     * two vectors are {@code NaN}, then the vectors are considered different.
+     * This implies that {@link #NaN Vector2D.NaN}.equals({@link #NaN Vector2D.NaN})
+     * returns {@code false} despite the instance is checked against itself.
      * </p>
      *
      * @param other Object to test for equality to this
@@ -484,17 +518,13 @@ public class Vector2D implements Vector<Euclidean2D> {
     @Override
     public boolean equals(Object other) {
 
-        if (this == other) {
+        if (this == other && !isNaN()) {
             return true;
         }
 
         if (other instanceof Vector2D) {
-            final Vector2D rhs = (Vector2D)other;
-            if (rhs.isNaN()) {
-                return this.isNaN();
-            }
-
-            return (x == rhs.x) && (y == rhs.y);
+            final Vector2D rhs = (Vector2D) other;
+            return x == rhs.x && y == rhs.y;
         }
         return false;
     }

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/spherical/oned/S1Point.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/spherical/oned/S1Point.java
@@ -108,26 +108,26 @@ public class S1Point implements Point<Sphere1D> {
     }
 
     /**
-     * Test for the equality of two points on the 2-sphere.
+     * Test for the equality of two points on the 1-sphere.
      * <p>
      * If all coordinates of two points are exactly the same, and none are
-     * <code>Double.NaN</code>, the two points are considered to be equal.
+     * {@code Double.NaN}, the two points are considered to be equal.
      * </p>
      * <p>
-     * <code>NaN</code> coordinates are considered to affect globally the vector
+     * {@code NaN} coordinates are considered to affect globally the point
      * and be equals to each other - i.e, if either (or all) coordinates of the
-     * 2D vector are equal to <code>Double.NaN</code>, the 2D vector is equal to
+     * point are equal to {@code Double.NaN}, the point is equal to
      * {@link #NaN}.
      * </p>
      *
      * @param other Object to test for equality to this
-     * @return true if two points on the 2-sphere objects are equal, false if
-     *         object is null, not an instance of S2Point, or
-     *         not equal to this S2Point instance
+     * @return true if two points on the 1-sphere objects are equal, false if
+     *         object is null, not an instance of S1Point, or
+     *         not equal to this S1Point instance
      *
+     * @since 3.0
      */
-    @Override
-    public boolean equals(Object other) {
+    public boolean equalsIncludingNaN(Object other) {
 
         if (this == other) {
             return true;
@@ -135,10 +135,40 @@ public class S1Point implements Point<Sphere1D> {
 
         if (other instanceof S1Point) {
             final S1Point rhs = (S1Point) other;
-            if (rhs.isNaN()) {
-                return this.isNaN();
-            }
+            return alpha == rhs.alpha || isNaN() && rhs.isNaN();
+        }
 
+        return false;
+
+    }
+
+    /**
+     * Test for the equality of two points on the 1-sphere.
+     * <p>
+     * If all coordinates of two points are exactly the same, and none are
+     * {@code Double.NaN}, the two points are considered to be equal.
+     * </p>
+     * <p>
+     * In compliance with IEEE754 handling, if any coordinates of any of the
+     * two points are {@code NaN}, then the points are considered different.
+     * This implies that {@link #NaN S1Point.NaN}.equals({@link #NaN S1Point.NaN})
+     * returns {@code false} despite the instance is checked against itself.
+     * </p>
+     *
+     * @param other Object to test for equality to this
+     * @return true if two points objects are equal, false if
+     *         object is null, not an instance of S1Point, or
+     *         not equal to this S1Point instance
+     */
+    @Override
+    public boolean equals(Object other) {
+
+        if (this == other && !isNaN()) {
+            return true;
+        }
+
+        if (other instanceof S1Point) {
+            final S1Point rhs = (S1Point) other;
             return alpha == rhs.alpha;
         }
 
@@ -147,7 +177,7 @@ public class S1Point implements Point<Sphere1D> {
     }
 
     /**
-     * Get a hashCode for the 2D vector.
+     * Get a hashCode for the point.
      * <p>
      * All NaN values have the same hash code.</p>
      *

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/spherical/twod/S2Point.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/spherical/twod/S2Point.java
@@ -190,12 +190,12 @@ public class S2Point implements Point<Sphere2D> {
      * Test for the equality of two points on the 2-sphere.
      * <p>
      * If all coordinates of two points are exactly the same, and none are
-     * <code>Double.NaN</code>, the two points are considered to be equal.
+     * {@code Double.NaN}, the two points are considered to be equal.
      * </p>
      * <p>
-     * <code>NaN</code> coordinates are considered to affect globally the vector
+     * {@code NaN} coordinates are considered to affect globally the point
      * and be equals to each other - i.e, if either (or all) coordinates of the
-     * 2D vector are equal to <code>Double.NaN</code>, the 2D vector is equal to
+     * point are equal to {@code Double.NaN}, the point is equal to
      * {@link #NaN}.
      * </p>
      *
@@ -204,9 +204,9 @@ public class S2Point implements Point<Sphere2D> {
      *         object is null, not an instance of S2Point, or
      *         not equal to this S2Point instance
      *
+     * @since 3.0
      */
-    @Override
-    public boolean equals(Object other) {
+    public boolean equalsIncludingNaN(Object other) {
 
         if (this == other) {
             return true;
@@ -214,17 +214,49 @@ public class S2Point implements Point<Sphere2D> {
 
         if (other instanceof S2Point) {
             final S2Point rhs = (S2Point) other;
-            if (rhs.isNaN()) {
-                return this.isNaN();
-            }
-
-            return (theta == rhs.theta) && (phi == rhs.phi);
+            return theta == rhs.theta && phi == rhs.phi || isNaN() && rhs.isNaN();
         }
+
         return false;
+
     }
 
     /**
-     * Get a hashCode for the 2D vector.
+     * Test for the equality of two points on the 2-sphere.
+     * <p>
+     * If all coordinates of two points are exactly the same, and none are
+     * {@code Double.NaN}, the two points are considered to be equal.
+     * </p>
+     * <p>
+     * In compliance with IEEE754 handling, if any coordinates of any of the
+     * two points are {@code NaN}, then the points are considered different.
+     * This implies that {@link #NaN S2Point.NaN}.equals({@link #NaN S2Point.NaN})
+     * returns {@code false} despite the instance is checked against itself.
+     * </p>
+     *
+     * @param other Object to test for equality to this
+     * @return true if two points objects are equal, false if
+     *         object is null, not an instance of S2Point, or
+     *         not equal to this S2Point instance
+     */
+    @Override
+    public boolean equals(Object other) {
+
+        if (this == other && !isNaN()) {
+            return true;
+        }
+
+        if (other instanceof S2Point) {
+            final S2Point rhs = (S2Point) other;
+            return phi == rhs.phi && theta == rhs.theta;
+        }
+
+        return false;
+
+    }
+
+    /**
+     * Get a hashCode for the point.
      * <p>
      * All NaN values have the same hash code.</p>
      *

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/oned/Vector1DFormatAbstractTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/oned/Vector1DFormatAbstractTest.java
@@ -299,7 +299,7 @@ public abstract class Vector1DFormatAbstractTest {
     public void testParseNan() throws MathIllegalStateException {
         String source = "{(NaN)}";
         Vector1D actual = vector1DFormat.parse(source);
-        Assert.assertEquals(Vector1D.NaN, actual);
+        Assert.assertTrue(Vector1D.NaN.equalsIncludingNaN(actual));
     }
 
     @Test

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/oned/Vector1DTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/oned/Vector1DTest.java
@@ -30,6 +30,8 @@ import java.util.Locale;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.MathRuntimeException;
 import org.hipparchus.geometry.Space;
+import org.hipparchus.geometry.euclidean.twod.FieldVector2D;
+import org.hipparchus.util.Decimal64Field;
 import org.hipparchus.util.FastMath;
 import org.hipparchus.util.Precision;
 import org.junit.Assert;
@@ -65,13 +67,29 @@ public class Vector1DTest {
     }
 
     @Test
+    public void testEqualsIncludingNaN() {
+        Vector1D u1 = new Vector1D(1);
+        Vector1D u2 = new Vector1D(1);
+        Assert.assertTrue(u1.equalsIncludingNaN(u1));
+        Assert.assertTrue(u1.equalsIncludingNaN(u2));
+        Assert.assertFalse(u1.equalsIncludingNaN(FieldVector2D.getPlusI(Decimal64Field.getInstance())));
+        Assert.assertFalse(u1.equalsIncludingNaN(new Vector1D(1 + 10 * Precision.EPSILON)));
+        Assert.assertTrue(new Vector1D(Double.NaN).equalsIncludingNaN(new Vector1D(Double.NaN)));
+        Assert.assertTrue(Vector1D.NaN.equalsIncludingNaN(Vector1D.NaN));
+    }
+
+    @SuppressWarnings("unlikely-arg-type")
+    @Test
     public void testEquals() {
         Vector1D u1 = new Vector1D(1);
         Vector1D u2 = new Vector1D(1);
         Assert.assertTrue(u1.equals(u1));
         Assert.assertTrue(u1.equals(u2));
+        Assert.assertFalse(u1.equals(FieldVector2D.getPlusI(Decimal64Field.getInstance())));
         Assert.assertFalse(u1.equals(new Vector1D(1 + 10 * Precision.EPSILON)));
-        Assert.assertTrue(new Vector1D(Double.NaN).equals(new Vector1D(Double.NaN)));
+        Assert.assertFalse(new Vector1D(Double.NaN).equals(new Vector1D(Double.NaN)));
+        Assert.assertFalse(Vector1D.NaN.equals(Vector1D.NaN));
+        Assert.assertFalse(Vector1D.NaN.equals(Vector1D.NaN));
     }
 
     @Test

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/threed/Vector3DFormatAbstractTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/threed/Vector3DFormatAbstractTest.java
@@ -347,7 +347,7 @@ public abstract class Vector3DFormatAbstractTest {
     public void testParseNan() throws MathIllegalStateException {
         String source = "{(NaN); (NaN); (NaN)}";
         Vector3D actual = vector3DFormat.parse(source);
-        Assert.assertEquals(Vector3D.NaN, actual);
+        Assert.assertTrue(Vector3D.NaN.equalsIncludingNaN(actual));
     }
 
     @Test

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/threed/Vector3DTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/threed/Vector3DTest.java
@@ -73,6 +73,19 @@ public class Vector3DTest {
         Assert.assertEquals(0, new Vector3D(1, 2, 2).getZero().getNorm(), 1.0e-15);
     }
 
+    @Test
+    public void testEqualsIncludingNaN() {
+        Vector3D u1 = new Vector3D(1, 2, 3);
+        Vector3D u2 = new Vector3D(1, 2, 3);
+        Assert.assertTrue(u1.equalsIncludingNaN(u1));
+        Assert.assertTrue(u1.equalsIncludingNaN(u2));
+        Assert.assertFalse(u1.equalsIncludingNaN(new Rotation(1, 0, 0, 0, false)));
+        Assert.assertFalse(u1.equalsIncludingNaN(new Vector3D(1, 2, 3 + 10 * Precision.EPSILON)));
+        Assert.assertFalse(u1.equalsIncludingNaN(new Vector3D(1, 2 + 10 * Precision.EPSILON, 3)));
+        Assert.assertFalse(u1.equalsIncludingNaN(new Vector3D(1 + 10 * Precision.EPSILON, 2, 3)));
+        Assert.assertTrue(new Vector3D(0, Double.NaN, 0).equalsIncludingNaN(new Vector3D(0, 0, Double.NaN)));
+    }
+
     @SuppressWarnings("unlikely-arg-type")
     @Test
     public void testEquals() {
@@ -84,7 +97,8 @@ public class Vector3DTest {
         Assert.assertFalse(u1.equals(new Vector3D(1, 2, 3 + 10 * Precision.EPSILON)));
         Assert.assertFalse(u1.equals(new Vector3D(1, 2 + 10 * Precision.EPSILON, 3)));
         Assert.assertFalse(u1.equals(new Vector3D(1 + 10 * Precision.EPSILON, 2, 3)));
-        Assert.assertTrue(new Vector3D(0, Double.NaN, 0).equals(new Vector3D(0, 0, Double.NaN)));
+        Assert.assertFalse(new Vector3D(0, Double.NaN, 0).equals(new Vector3D(0, 0, Double.NaN)));
+        Assert.assertFalse(Vector3D.NaN.equals(Vector3D.NaN));
     }
 
     @Test

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/twod/Vector2DFormatAbstractTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/twod/Vector2DFormatAbstractTest.java
@@ -333,7 +333,7 @@ public abstract class Vector2DFormatAbstractTest {
     public void testParseNan() throws MathIllegalStateException {
         String source = "{(NaN); (NaN)}";
         Vector2D actual = vector2DFormat.parse(source);
-        Assert.assertEquals(Vector2D.NaN, actual);
+        Assert.assertTrue(Vector2D.NaN.equalsIncludingNaN(actual));
     }
 
     @Test

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/twod/Vector2DTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/twod/Vector2DTest.java
@@ -206,19 +206,36 @@ public class Vector2DTest {
         Assert.assertFalse(Vector2D.MINUS_I.isInfinite());
     }
 
+    @Test public void testEqualsIncludingNaN() {
+        final Vector2D u1 = Vector2D.PLUS_I;
+        final Vector2D u2 = Vector2D.MINUS_I.negate();
+        final Vector2D v1 = new Vector2D(1.0, 0.001);
+        final Vector2D v2 = new Vector2D(0.001, 1.0);
+        Assert.assertTrue(u1.equalsIncludingNaN(u1));
+        Assert.assertTrue(u1.equalsIncludingNaN(u2));
+        Assert.assertFalse(u1.equalsIncludingNaN(v1));
+        Assert.assertFalse(u1.equalsIncludingNaN(v2));
+        Assert.assertFalse(u1.equalsIncludingNaN(FieldVector2D.getPlusI(Decimal64Field.getInstance())));
+        Assert.assertTrue(new Vector2D(Double.NaN, u1).equalsIncludingNaN(Vector2D.NaN));
+        Assert.assertFalse(u1.equalsIncludingNaN(Vector2D.NaN));
+        Assert.assertFalse(Vector2D.NaN.equalsIncludingNaN(v2));
+    }
+
+    @SuppressWarnings("unlikely-arg-type")
     @Test public void testEquals() {
         final Vector2D u1 = Vector2D.PLUS_I;
         final Vector2D u2 = Vector2D.MINUS_I.negate();
         final Vector2D v1 = new Vector2D(1.0, 0.001);
         final Vector2D v2 = new Vector2D(0.001, 1.0);
-        Assert.assertEquals(u1, u1);
-        Assert.assertEquals(u1, u2);
-        Assert.assertNotEquals(u1, v1);
-        Assert.assertNotEquals(u1, v2);
-        Assert.assertNotEquals(u1, FieldVector2D.getPlusI(Decimal64Field.getInstance()));
-        Assert.assertEquals(new Vector2D(Double.NaN, u1), Vector2D.NaN);
-        Assert.assertNotEquals(u1, Vector2D.NaN);
-        Assert.assertNotEquals(Vector2D.NaN, v2);
+        Assert.assertTrue(u1.equals(u1));
+        Assert.assertTrue(u1.equals(u2));
+        Assert.assertFalse(u1.equals(v1));
+        Assert.assertFalse(u1.equals(v2));
+        Assert.assertFalse(u1.equals(FieldVector2D.getPlusI(Decimal64Field.getInstance())));
+        Assert.assertFalse(new Vector2D(Double.NaN, u1).equals(Vector2D.NaN));
+        Assert.assertFalse(u1.equals(Vector2D.NaN));
+        Assert.assertFalse(Vector2D.NaN.equals(v2));
+        Assert.assertFalse(Vector2D.NaN.equals(Vector2D.NaN));
     }
 
     @Test public void testHashCode() {

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/spherical/oned/S1PointTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/spherical/oned/S1PointTest.java
@@ -42,8 +42,21 @@ public class S1PointTest {
     @Test
     public void testNaN() {
         Assert.assertTrue(S1Point.NaN.isNaN());
-        Assert.assertTrue(S1Point.NaN.equals(new S1Point(Double.NaN)));
+        Assert.assertTrue(S1Point.NaN.equalsIncludingNaN(new S1Point(Double.NaN)));
         Assert.assertFalse(new S1Point(1.0).equals(S1Point.NaN));
+    }
+
+    @Test
+    public void testEqualsIncludingNaN() {
+        S1Point a = new S1Point(1.0);
+        S1Point b = new S1Point(1.0);
+        Assert.assertEquals(a.hashCode(), b.hashCode());
+        Assert.assertFalse(a == b);
+        Assert.assertTrue(a.equalsIncludingNaN(b));
+        Assert.assertTrue(a.equalsIncludingNaN(a));
+        Assert.assertFalse(a.equalsIncludingNaN('a'));
+        Assert.assertTrue(S1Point.NaN.equalsIncludingNaN(S1Point.NaN));
+        Assert.assertTrue(S1Point.NaN.equalsIncludingNaN(new S1Point(Double.NaN)));
     }
 
     @SuppressWarnings("unlikely-arg-type")
@@ -56,6 +69,8 @@ public class S1PointTest {
         Assert.assertTrue(a.equals(b));
         Assert.assertTrue(a.equals(a));
         Assert.assertFalse(a.equals('a'));
+        Assert.assertFalse(S1Point.NaN.equals(S1Point.NaN));
+        Assert.assertFalse(S1Point.NaN.equals(new S1Point(Double.NaN)));
     }
 
     @Test

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/spherical/twod/S2PointTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/spherical/twod/S2PointTest.java
@@ -57,8 +57,22 @@ public class S2PointTest {
     @Test
     public void testNaN() {
         Assert.assertTrue(S2Point.NaN.isNaN());
-        Assert.assertTrue(S2Point.NaN.equals(new S2Point(Double.NaN, 1.0)));
+        Assert.assertTrue(S2Point.NaN.equalsIncludingNaN(new S2Point(Double.NaN, 1.0)));
         Assert.assertFalse(new S2Point(1.0, 1.3).equals(S2Point.NaN));
+    }
+
+    @Test
+    public void testEqualsIncludingNaN() {
+        S2Point a = new S2Point(1.0, 1.0);
+        S2Point b = new S2Point(1.0, 1.0);
+        Assert.assertEquals(a.hashCode(), b.hashCode());
+        Assert.assertFalse(a == b);
+        Assert.assertTrue(a.equalsIncludingNaN(b));
+        Assert.assertTrue(a.equalsIncludingNaN(a));
+        Assert.assertFalse(a.equalsIncludingNaN('a'));
+        Assert.assertTrue(S2Point.NaN.equalsIncludingNaN(S2Point.NaN));
+        Assert.assertTrue(S2Point.NaN.equalsIncludingNaN(new S2Point(Double.NaN, 0.0)));
+        Assert.assertTrue(S2Point.NaN.equalsIncludingNaN(new S2Point(0.0, Double.NaN)));
     }
 
     @SuppressWarnings("unlikely-arg-type")
@@ -71,6 +85,9 @@ public class S2PointTest {
         Assert.assertTrue(a.equals(b));
         Assert.assertTrue(a.equals(a));
         Assert.assertFalse(a.equals('a'));
+        Assert.assertFalse(S2Point.NaN.equals(S2Point.NaN));
+        Assert.assertFalse(S2Point.NaN.equals(new S2Point(Double.NaN, 0.0)));
+        Assert.assertFalse(S2Point.NaN.equals(new S2Point(0.0, Double.NaN)));
     }
 
     @Test

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -49,6 +49,13 @@ If the output is not quite correct, check for invisible trailing spaces!
     <title>Hipparchus Release Notes</title>
   </properties>
   <body>
+    <release version="3.0" date="TBD" description="TBD">
+      <action dev="luc" type="update">
+        Make equals consistent with IEEE754 concerning NaN coordinates
+        for S1Point, S2Point, Vector1D, Vector2D and Vector3D (i.e. when
+        there is a NaN anywhere, equals returns false).
+      </action>
+    </release>
     <release version="2.1" date="TBD" description="TBD">
       <action dev="luc" type="fix" issue="issue/178">
         Added Modified Gram-Schmidt basis orthonormalization process in MatrixUtils


### PR DESCRIPTION
When there is a NaN anywhere, equals now returns false.

This semantic change has been made on S1Point, S2Point, Vector1D,
Vector2D and Vector3D.