### PR TITLE
Added new signature for SequentialGaussNewtonOptimizer#withAPrioriData.

### DIFF
--- a/hipparchus-optim/src/changes/changes.xml
+++ b/hipparchus-optim/src/changes/changes.xml
@@ -49,6 +49,12 @@ If the output is not quite correct, check for invisible trailing spaces!
     <title>Hipparchus Optim Release Notes</title>
   </properties>
   <body>
+    <release version="2.3" date="TBD" description="TBD">
+      <action dev="bryan" type="add">
+        Added new signature for SequentialGaussNewtonOptimizer#withAPrioriData allowing
+        to defined the Cholesky decomposition thresholds.
+      </action>
+    </release>
     <release version="2.2" date="2022-08-10" description="This is a maintenance release.">
       <action dev="luc" type="update">
         No changes directly in this module. However, lower level Hipparchus modules did change,

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -50,6 +50,10 @@ If the output is not quite correct, check for invisible trailing spaces!
   </properties>
   <body>
     <release version="2.3" date="TBD" description="TBD">
+      <action dev="bryan" type="add" issue="issues/205">
+        Added new signature for SequentialGaussNewtonOptimizer#withAPrioriData allowing
+        to defined the Cholesky decomposition thresholds.
+      </action>
       <action dev="luc" type="add" issue="issues/204">
         Changed HessenbergTransformer visibility to public.
       </action>


### PR DESCRIPTION
The new signature allows to define the Cholesky decomposition
thresholds.

Fixes #205