### PR TITLE
Issue 212 : Adding Smoothstep functions and Blendable interface

### DIFF
--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/polynomials/SmoothStepFactory.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/polynomials/SmoothStepFactory.java
@@ -1,0 +1,152 @@
+package org.hipparchus.analysis.polynomials;
+
+import org.hipparchus.exception.LocalizedCoreFormats;
+import org.hipparchus.exception.MathIllegalArgumentException;
+import org.hipparchus.exception.NullArgumentException;
+import org.hipparchus.util.CombinatoricsUtils;
+import org.hipparchus.util.FastMath;
+
+/**
+ * Smoothstep function factory.
+ * <p>
+ * It allows for quick creation of common/generic smoothstep functions.
+ *
+ * @author Vincent Cucchietti
+ */
+public class SmoothStepFactory {
+
+    /**
+     * Get the {@link SmoothStepFunction clamping smoothstep function}.
+     * @return clamping smoothstep function
+     */
+    public static SmoothStepFunction getClamp() {
+        return getGeneralOrder(0);
+    }
+
+    /**
+     * Get the {@link SmoothStepFunction cubic smoothstep function}.
+     * @return cubic smoothstep function
+     */
+    public static SmoothStepFunction getCubic() {
+        return getGeneralOrder(1);
+    }
+
+    /**
+     * Get the {@link SmoothStepFunction quintic smoothstep function}.
+     * @return quintic smoothstep function
+     */
+    public static SmoothStepFunction getQuintic() {
+        return getGeneralOrder(2);
+    }
+
+    /**
+     * Create a {@link SmoothStepFunction smoothstep function} of order <b>2N + 1</b>.
+     * <p>
+     * It uses the general smoothstep equation presented <a href="https://en.wikipedia.org/wiki/Smoothstep">here</a>.
+     *
+     * @param N determines the order of the output smoothstep function (=2N + 1)
+     * @return smoothstep function of order <b>2N + 1</b>
+     */
+    public static SmoothStepFunction getGeneralOrder(final int N) {
+
+        final int twoNPlusOne = 2 * N + 1;
+
+        final double[] coefficients = new double[twoNPlusOne + 1];
+
+        int n = N;
+        for (int i = twoNPlusOne; i > N; i--) {
+
+            coefficients[i] = FastMath.pow(-1, n)
+                    * CombinatoricsUtils.binomialCoefficient(N + n, n)
+                    * CombinatoricsUtils.binomialCoefficient(twoNPlusOne, N - n);
+
+            n--;
+        }
+
+        return new SmoothStepFunction(coefficients);
+    }
+
+    /**
+     * Smoothstep function, it is used to do a smooth transition between the "left edge" and the "right edge" with left
+     * edge assumed to be smaller than the right edge.
+     * <p>
+     * By definition, for order n>1 and input x, a smoothstep function respects the following properties :
+     * <ul>
+     *     <li>f(x <= leftEdge) = leftEdge and f(x >= rightEdge) = rightEdge</li>
+     *     <li>f'(leftEdge) = f'(rightEdge) = 0</li>
+     * </ul>
+     * If x is normalized between edges, we have :
+     * <ul>
+     *     <li>f(x <= 0) = 0 and f(x >= 1) = 1</li>
+     *     <li>f'(0) = f'(1) = 0</li>
+     * </ul>
+     */
+    public static class SmoothStepFunction extends PolynomialFunction {
+
+        /**
+         * Construct a smoothstep with the given coefficients.  The first element of the coefficients array is the
+         * constant term.  Higher degree coefficients follow in sequence.  The degree of the resulting polynomial is the
+         * index of the last non-null element of the array, or 0 if all elements are null.
+         * <p>
+         * The constructor makes a copy of the input array and assigns the copy to the coefficients property.</p>
+         *
+         * @param c Smoothstep polynomial coefficients.
+         * @throws NullArgumentException if {@code c} is {@code null}.
+         * @throws MathIllegalArgumentException if {@code c} is empty.
+         */
+        private SmoothStepFunction(final double[] c) throws MathIllegalArgumentException, NullArgumentException {
+            super(c);
+        }
+
+        /**
+         * Compute the value of the smoothstep for the given argument normalized between edges.
+         *
+         * @param xNormalized Normalized argument for which the function value should be computed.
+         * @return the value of the polynomial at the given point.
+         * @see org.hipparchus.analysis.UnivariateFunction#value(double)
+         */
+        @Override
+        public double value(final double xNormalized) {
+
+            if (xNormalized <= 0) {
+                return 0;
+            }
+            if (xNormalized >= 1) {
+                return 1;
+            }
+
+            return super.value(xNormalized);
+        }
+
+        /**
+         * Compute the value of the smoothstep function for the given edges and argument.
+         * <p>
+         * This implementation is based on "Advanced Real-Time Shader Techniques". AND. p. 94. Retrieved 2022-04-16. by
+         * Natalya Tatarchuk (2003).
+         * </p>
+         *
+         * @param x Argument for which the function value should be computed.
+         * @return the value of the polynomial at the given point.
+         * @see org.hipparchus.analysis.UnivariateFunction#value(double)
+         */
+        public double value(final double leftEdge, final double rightEdge, final double x)
+                throws MathIllegalArgumentException {
+
+            if (leftEdge > rightEdge) {
+                throw new MathIllegalArgumentException(LocalizedCoreFormats.RIGHT_EDGE_GREATER_THAN_LEFT_EDGE,
+                                                       leftEdge, rightEdge);
+            }
+            if (x <= leftEdge) {
+                return 0;
+            }
+            if (x >= rightEdge) {
+                return 1;
+            }
+
+            final double xNormalized = (x - leftEdge) / (rightEdge - leftEdge);
+
+            return super.value(xNormalized);
+        }
+    }
+
+}

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/polynomials/SmoothStepFactory.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/polynomials/SmoothStepFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Hipparchus project under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The Hipparchus project licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hipparchus.analysis.polynomials;
 
 import org.hipparchus.exception.LocalizedCoreFormats;
@@ -7,7 +23,8 @@ import org.hipparchus.exception.NullArgumentException;
 /**
  * Smoothstep function factory.
  * <p>
- * It allows for quick creation of common and generic smoothstep functions.
+ * It allows for quick creation of common and generic smoothstep functions as defined <a
+ * href="https://en.wikipedia.org/wiki/Smoothstep>here</a>.
  */
 public class SmoothStepFactory {
 
@@ -51,7 +68,8 @@ public class SmoothStepFactory {
     /**
      * Create a {@link SmoothStepFunction smoothstep function} of order <b>2N + 1</b>.
      * <p>
-     * It uses the general smoothstep equation presented <a href="https://en.wikipedia.org/wiki/Smoothstep">here</a>.
+     * It uses the general smoothstep equation presented <a href="https://en.wikipedia.org/wiki/Smoothstep">here</a> :
+     * $S_{N}(x) = \sum_{n=0}^{N} \begin{pmatrix} -N-1 \\ n \end{pmatrix} \begin{pmatrix} 2N+1 \\ N-n \end{pmatrix} x^{N+n+1}$
      *
      * @param N determines the order of the output smoothstep function (=2N + 1)
      * @return smoothstep function of order <b>2N + 1</b>
@@ -74,8 +92,8 @@ public class SmoothStepFactory {
     /**
      * Returns binomial coefficient without explicit use of factorials, which can't be used with negative integers
      *
-     * @param n set
      * @param k subset in set
+     * @param n set
      * @return number of subset {@code k} in global set {@code n}
      */
     private static int pascalTriangle(final int k, final int n) {
@@ -89,7 +107,7 @@ public class SmoothStepFactory {
     }
 
     /**
-     * Check that input is between [0:1] included.
+     * Check that input is between [0:1].
      *
      * @param input input to be checked
      * @throws MathIllegalArgumentException if input is not between [0:1]
@@ -105,11 +123,11 @@ public class SmoothStepFactory {
      * Smoothstep function as defined <a href="https://en.wikipedia.org/wiki/Smoothstep>here</a>.
      * <p>
      * It is used to do a smooth transition between the "left edge" and the "right edge" with left edge assumed to be
-     * smaller than the right edge.
+     * smaller than right edge.
      * <p>
      * By definition, for order n > 1 and input x, a smoothstep function respects at least the following properties :
      * <ul>
-     *     <li>f(x <= leftEdge) = leftEdge and f(x >= rightEdge) = rightEdge</li>
+     *     <li>f(x <= leftEdge) = 0 and f(x >= rightEdge) = 1</li>
      *     <li>f'(leftEdge) = f'(rightEdge) = 0</li>
      * </ul>
      * If x is normalized between edges, we have at least :
@@ -117,6 +135,7 @@ public class SmoothStepFactory {
      *     <li>f(x <= 0) = 0 and f(x >= 1) = 1</li>
      *     <li>f'(0) = f'(1) = 0</li>
      * </ul>
+     * Smoothstep functions of higher order n will have their higher time derivatives also equal to zero at edges...
      */
     public static class SmoothStepFunction extends PolynomialFunction {
 

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/polynomials/SmoothStepFactory.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/polynomials/SmoothStepFactory.java
@@ -14,6 +14,16 @@ import org.hipparchus.exception.NullArgumentException;
 public class SmoothStepFactory {
 
     /**
+     * Private constructor.
+     * <p>
+     * This class is a utility class, it should neither have a public nor a default constructor. This private
+     * constructor prevents the compiler from generating one automatically.
+     */
+    private SmoothStepFactory() {
+        // Empty constructor
+    }
+
+    /**
      * Get the {@link SmoothStepFunction clamping smoothstep function}.
      *
      * @return clamping smoothstep function
@@ -70,11 +80,11 @@ public class SmoothStepFactory {
      * @param k subset in set
      * @return number of subset {@code k} in global set {@code n}
      */
-    private static int pascalTriangle(final int n, final int k) {
+    private static int pascalTriangle(final int k, final int n) {
 
         int result = 1;
-        for (int i = 0; i < k; i++) {
-            result *= (n - i) / (i + 1);
+        for (int i = 0; i < n; i++) {
+            result *= (k - i) / (i + 1);
         }
 
         return result;
@@ -151,9 +161,9 @@ public class SmoothStepFactory {
         public double value(final double leftEdge, final double rightEdge, final double x)
                 throws MathIllegalArgumentException {
 
-            checkInput(leftEdge, rightEdge);
+            checkInputEdges(leftEdge, rightEdge);
 
-            final double xClamped = clamp(leftEdge, rightEdge, x);
+            final double xClamped = clampInput(leftEdge, rightEdge, x);
 
             final double xNormalized = normalizeInput(leftEdge, rightEdge, xClamped);
 
@@ -166,7 +176,7 @@ public class SmoothStepFactory {
          * @param leftEdge left edge
          * @param rightEdge right edge
          */
-        private void checkInput(final double leftEdge, final double rightEdge) {
+        private void checkInputEdges(final double leftEdge, final double rightEdge) {
             if (leftEdge > rightEdge) {
                 throw new MathIllegalArgumentException(LocalizedCoreFormats.RIGHT_EDGE_GREATER_THAN_LEFT_EDGE,
                                                        leftEdge, rightEdge);
@@ -181,7 +191,7 @@ public class SmoothStepFactory {
          * @param x input to clamp
          * @return clamped input
          */
-        private double clamp(final double leftEdge, final double rightEdge, final double x) {
+        private double clampInput(final double leftEdge, final double rightEdge, final double x) {
             if (x <= leftEdge) {
                 return leftEdge;
             }

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/polynomials/SmoothStepFactory.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/polynomials/SmoothStepFactory.java
@@ -8,8 +8,6 @@ import org.hipparchus.exception.NullArgumentException;
  * Smoothstep function factory.
  * <p>
  * It allows for quick creation of common and generic smoothstep functions.
- *
- * @author Vincent Cucchietti
  */
 public class SmoothStepFactory {
 
@@ -153,9 +151,14 @@ public class SmoothStepFactory {
 
         /**
          * Compute the value of the smoothstep function for the given edges and argument.
+         * <p>
+         * Note that right edge is expected to be greater than left edge. It will throw an exception otherwise.
          *
-         * @param x Argument for which the function value should be computed.
-         * @return the value of the polynomial at the given point.
+         * @param leftEdge left edge
+         * @param rightEdge right edge
+         * @param x Argument for which the function value should be computed
+         * @return the value of the polynomial at the given point
+         * @throws MathIllegalArgumentException if right edge is greater than left edge
          * @see org.hipparchus.analysis.UnivariateFunction#value(double)
          */
         public double value(final double leftEdge, final double rightEdge, final double x)

--- a/hipparchus-core/src/main/java/org/hipparchus/exception/LocalizedCoreFormats.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/exception/LocalizedCoreFormats.java
@@ -227,7 +227,8 @@ public enum LocalizedCoreFormats implements Localizable {
     ZERO_NORM("zero norm"),
     ZERO_NOT_ALLOWED("zero not allowed here"),
     ZERO_STATE_SIZE("state dimension must be different from 0"),
-    RIGHT_EDGE_GREATER_THAN_LEFT_EDGE("Left edge {0} should be smaller than right edge {1}");
+    RIGHT_EDGE_GREATER_THAN_LEFT_EDGE("left edge {0} should be smaller than right edge {1}"),
+    INPUT_EXPECTED_BETWEEN_ZERO_AND_ONE_INCLUDED("input {0} is expected to be between [0:1]");
 
 
     // CHECKSTYLE: resume JavadocVariable

--- a/hipparchus-core/src/main/java/org/hipparchus/exception/LocalizedCoreFormats.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/exception/LocalizedCoreFormats.java
@@ -226,7 +226,9 @@ public enum LocalizedCoreFormats implements Localizable {
     ZERO_FRACTION_TO_DIVIDE_BY("the fraction to divide by must not be zero: {0}/{1}"),
     ZERO_NORM("zero norm"),
     ZERO_NOT_ALLOWED("zero not allowed here"),
-    ZERO_STATE_SIZE("state dimension must be different from 0");
+    ZERO_STATE_SIZE("state dimension must be different from 0"),
+    RIGHT_EDGE_GREATER_THAN_LEFT_EDGE("Left edge {0} should be smaller than right edge {1}");
+
 
     // CHECKSTYLE: resume JavadocVariable
     // CHECKSTYLE: resume MultipleVariableDeclarations

--- a/hipparchus-core/src/main/java/org/hipparchus/linear/AbstractRealMatrix.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/AbstractRealMatrix.java
@@ -28,7 +28,6 @@ import java.util.Locale;
 import org.hipparchus.exception.LocalizedCoreFormats;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.NullArgumentException;
-import org.hipparchus.util.Blendable;
 import org.hipparchus.util.FastMath;
 import org.hipparchus.util.MathUtils;
 
@@ -39,7 +38,7 @@ import org.hipparchus.util.MathUtils;
  *
  */
 public abstract class AbstractRealMatrix
-    implements RealMatrix, RealLinearOperator, Blendable<RealMatrix> {
+    implements RealMatrix, RealLinearOperator {
 
     /** Default format. */
     private static final RealMatrixFormat DEFAULT_FORMAT = RealMatrixFormat.getRealMatrixFormat(Locale.US);

--- a/hipparchus-core/src/main/java/org/hipparchus/linear/AbstractRealMatrix.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/AbstractRealMatrix.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import org.hipparchus.exception.LocalizedCoreFormats;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.NullArgumentException;
+import org.hipparchus.util.Blendable;
 import org.hipparchus.util.FastMath;
 import org.hipparchus.util.MathUtils;
 
@@ -38,7 +39,7 @@ import org.hipparchus.util.MathUtils;
  *
  */
 public abstract class AbstractRealMatrix
-    implements RealMatrix, RealLinearOperator {
+    implements RealMatrix, RealLinearOperator, Blendable<RealMatrix> {
 
     /** Default format. */
     private static final RealMatrixFormat DEFAULT_FORMAT = RealMatrixFormat.getRealMatrixFormat(Locale.US);

--- a/hipparchus-core/src/main/java/org/hipparchus/linear/RealMatrix.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/RealMatrix.java
@@ -23,8 +23,10 @@
 package org.hipparchus.linear;
 
 import org.hipparchus.analysis.UnivariateFunction;
+import org.hipparchus.analysis.polynomials.SmoothStepFactory;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.NullArgumentException;
+import org.hipparchus.util.Blendable;
 import org.hipparchus.util.FastMath;
 
 /**
@@ -34,7 +36,7 @@ import org.hipparchus.util.FastMath;
  * returns the element in the first row, first column of the matrix.</p>
  *
  */
-public interface RealMatrix extends AnyMatrix {
+public interface RealMatrix extends AnyMatrix, Blendable<RealMatrix> {
 
     /**
      * Create a new RealMatrix of the same type as the instance with the
@@ -164,6 +166,13 @@ public interface RealMatrix extends AnyMatrix {
      */
     RealMatrix power(int p)
         throws MathIllegalArgumentException;
+
+    /** {@inheritDoc} */
+    @Override
+    default RealMatrix blendArithmeticallyWith(final RealMatrix other, final double blendingValue) {
+        SmoothStepFactory.checkBetweenZeroAndOneIncluded(blendingValue);
+        return this.scalarMultiply(1 - blendingValue).add(other.scalarMultiply(blendingValue));
+    }
 
     /**
      * Returns matrix entries as a two-dimensional array.

--- a/hipparchus-core/src/main/java/org/hipparchus/util/Blendable.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/util/Blendable.java
@@ -1,0 +1,22 @@
+package org.hipparchus.util;
+
+import org.hipparchus.exception.MathIllegalArgumentException;
+
+/**
+ * Interface representing classes that can blend with other instances of themselves using a given smoothstep function.
+ *
+ * @param <B> blendable class
+ */
+public interface Blendable<B> {
+
+    /**
+     * Blend arithmetically this instance with another one.
+     *
+     * @param other other instance to blend arithmetically with
+     * @param blendingValue value from smoothstep function B(x). It is expected to be between [0:1] and will
+     *         throw an exception otherwise.
+     * @return this * (1 - B(x)) + other * B(x)
+     * @throws MathIllegalArgumentException if blending value is not within [0:1]
+     */
+    B blendArithmeticallyWith(B other, double blendingValue) throws MathIllegalArgumentException;
+}

--- a/hipparchus-core/src/main/java/org/hipparchus/util/Blendable.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/util/Blendable.java
@@ -1,9 +1,27 @@
+/*
+ * Licensed to the Hipparchus project under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The Hipparchus project licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hipparchus.util;
 
 import org.hipparchus.exception.MathIllegalArgumentException;
 
 /**
- * Interface representing classes that can blend with other instances of themselves using a given smoothstep function.
+ * Interface representing classes that can blend with other instances of themselves using a given blending value.
+ * <p> The blending value is commonly given from a
+ * {@link org.hipparchus.analysis.polynomials.SmoothStepFactory.SmoothStepFunction smoothstep function}.
  *
  * @param <B> blendable class
  */

--- a/hipparchus-core/src/main/resources/assets/org/hipparchus/exception/LocalizedCoreFormats_fr.utf8
+++ b/hipparchus-core/src/main/resources/assets/org/hipparchus/exception/LocalizedCoreFormats_fr.utf8
@@ -199,4 +199,5 @@ ZERO_NORM = norme nulle
 ZERO_NOT_ALLOWED = la valeur zéro n''est pas autorisée ici
 ZERO_STATE_SIZE = la dimension de l''état doit être différente de 0
 NEGATIVE_DEFINITE_MATRIX = la matrice ne doit pas être définie négative
-RIGHT_EDGE_GREATER_THAN_LEFT_EDGE = Le bord gauche {0} doit être plus petit que le bord droit {1}
+RIGHT_EDGE_GREATER_THAN_LEFT_EDGE = le bord gauche {0} doit être plus petit que le bord droit {1}
+INPUT_EXPECTED_BETWEEN_ZERO_AND_ONE_INCLUDED = l''entrée {0} doit être comprise entre [0:1]

--- a/hipparchus-core/src/main/resources/assets/org/hipparchus/exception/LocalizedCoreFormats_fr.utf8
+++ b/hipparchus-core/src/main/resources/assets/org/hipparchus/exception/LocalizedCoreFormats_fr.utf8
@@ -199,3 +199,4 @@ ZERO_NORM = norme nulle
 ZERO_NOT_ALLOWED = la valeur zéro n''est pas autorisée ici
 ZERO_STATE_SIZE = la dimension de l''état doit être différente de 0
 NEGATIVE_DEFINITE_MATRIX = la matrice ne doit pas être définie négative
+RIGHT_EDGE_GREATER_THAN_LEFT_EDGE = Le bord gauche {0} doit être plus petit que le bord droit {1}

--- a/hipparchus-core/src/test/java/org/hipparchus/analysis/polynomials/SmoothStepFactoryTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/analysis/polynomials/SmoothStepFactoryTest.java
@@ -1,6 +1,5 @@
 package org.hipparchus.analysis.polynomials;
 
-import junit.framework.TestCase;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -10,7 +9,7 @@ public class SmoothStepFactoryTest {
     final double THRESHOLD = 1e-15;
 
     @Test(expected = MathIllegalArgumentException.class)
-    public void testException() {
+    public void testExceptionLeftAndRightEdge() {
         // Given
         final double leftEdge  = 5;
         final double rightEdge = leftEdge - 1;
@@ -21,31 +20,58 @@ public class SmoothStepFactoryTest {
         smoothstep.value(leftEdge, rightEdge, 0);
     }
 
+    @Test(expected = MathIllegalArgumentException.class)
+    public void testExceptionBelowBoundary() {
+        // Given
+        final double x           = 2;
+        final SmoothStepFactory.SmoothStepFunction smoothstep = SmoothStepFactory.getGeneralOrder(1);
+
+        // When
+        smoothstep.value(x);
+    }
+
+    @Test(expected = MathIllegalArgumentException.class)
+    public void testExceptionOverBoundary() {
+        // Given
+        final double x           = 17;
+        final SmoothStepFactory.SmoothStepFunction smoothstep = SmoothStepFactory.getGeneralOrder(1);
+
+        // When
+        smoothstep.value(x);
+    }
+
     @Test
     public void testBoundaries() {
         // Given
         final double leftEdge     = 5;
         final double rightEdge    = 10;
         final double x1           = 2;
-        final double x1Normalized = (x1 - leftEdge) / (rightEdge - leftEdge);
         final double x2           = 11;
-        final double x2Normalized = (x2 - leftEdge) / (rightEdge - leftEdge);
 
         final SmoothStepFactory.SmoothStepFunction clamp = SmoothStepFactory.getClamp();
 
         // When
         final double computedResult1           = clamp.value(leftEdge, rightEdge, x1);
         final double computedResult2           = clamp.value(leftEdge, rightEdge, x2);
-        final double computedResult1Normalized = clamp.value(x1Normalized);
-        final double computedResult2Normalized = clamp.value(x2Normalized);
 
         // Then
         Assert.assertEquals(0, computedResult1, THRESHOLD);
         Assert.assertEquals(1, computedResult2, THRESHOLD);
-        Assert.assertEquals(0, computedResult1Normalized, THRESHOLD);
-        Assert.assertEquals(1, computedResult2Normalized, THRESHOLD);
-        Assert.assertEquals(computedResult1, computedResult1Normalized, THRESHOLD);
-        Assert.assertEquals(computedResult2, computedResult2Normalized, THRESHOLD);
+    }
+
+    @Test
+    public void testNormalizedInput() {
+
+        // Given
+        final double x         = 0.4;
+        final SmoothStepFactory.SmoothStepFunction clamp = SmoothStepFactory.getCubic();
+
+        // When
+        final double computedResult = clamp.value(x);
+
+        // Then
+        Assert.assertEquals(0.352, computedResult, THRESHOLD);
+
     }
 
     @Test
@@ -54,7 +80,7 @@ public class SmoothStepFactoryTest {
         // Given
         final double leftEdge  = 5;
         final double rightEdge = 10;
-        final double x        = 7;
+        final double x         = 7;
 
         final SmoothStepFactory.SmoothStepFunction clamp = SmoothStepFactory.getClamp();
 
@@ -72,7 +98,7 @@ public class SmoothStepFactoryTest {
         // Given
         final double leftEdge  = 5;
         final double rightEdge = 10;
-        final double x        = 7;
+        final double x         = 7;
 
         final SmoothStepFactory.SmoothStepFunction cubic = SmoothStepFactory.getCubic();
 
@@ -90,7 +116,7 @@ public class SmoothStepFactoryTest {
         // Given
         final double leftEdge  = 5;
         final double rightEdge = 10;
-        final double x        = 7;
+        final double x         = 7;
 
         final SmoothStepFactory.SmoothStepFunction quintic = SmoothStepFactory.getQuintic();
 

--- a/hipparchus-core/src/test/java/org/hipparchus/analysis/polynomials/SmoothStepFactoryTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/analysis/polynomials/SmoothStepFactoryTest.java
@@ -23,7 +23,7 @@ public class SmoothStepFactoryTest {
     @Test(expected = MathIllegalArgumentException.class)
     public void testExceptionBelowBoundary() {
         // Given
-        final double x           = 2;
+        final double                               x          = 2;
         final SmoothStepFactory.SmoothStepFunction smoothstep = SmoothStepFactory.getGeneralOrder(1);
 
         // When
@@ -33,7 +33,7 @@ public class SmoothStepFactoryTest {
     @Test(expected = MathIllegalArgumentException.class)
     public void testExceptionOverBoundary() {
         // Given
-        final double x           = 17;
+        final double                               x          = 17;
         final SmoothStepFactory.SmoothStepFunction smoothstep = SmoothStepFactory.getGeneralOrder(1);
 
         // When
@@ -63,7 +63,7 @@ public class SmoothStepFactoryTest {
     public void testNormalizedInput() {
 
         // Given
-        final double x         = 0.4;
+        final double                               x     = 0.4;
         final SmoothStepFactory.SmoothStepFunction clamp = SmoothStepFactory.getCubic();
 
         // When

--- a/hipparchus-core/src/test/java/org/hipparchus/analysis/polynomials/SmoothStepFactoryTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/analysis/polynomials/SmoothStepFactoryTest.java
@@ -1,0 +1,105 @@
+package org.hipparchus.analysis.polynomials;
+
+import junit.framework.TestCase;
+import org.hipparchus.exception.MathIllegalArgumentException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SmoothStepFactoryTest {
+
+    final double THRESHOLD = 1e-15;
+
+    @Test(expected = MathIllegalArgumentException.class)
+    public void testException() {
+        // Given
+        final double leftEdge  = 5;
+        final double rightEdge = leftEdge - 1;
+
+        final SmoothStepFactory.SmoothStepFunction smoothstep = SmoothStepFactory.getGeneralOrder(1);
+
+        // When
+        smoothstep.value(leftEdge, rightEdge, 0);
+    }
+
+    @Test
+    public void testBoundaries() {
+        // Given
+        final double leftEdge     = 5;
+        final double rightEdge    = 10;
+        final double x1           = 2;
+        final double x1Normalized = (x1 - leftEdge) / (rightEdge - leftEdge);
+        final double x2           = 11;
+        final double x2Normalized = (x2 - leftEdge) / (rightEdge - leftEdge);
+
+        final SmoothStepFactory.SmoothStepFunction clamp = SmoothStepFactory.getClamp();
+
+        // When
+        final double computedResult1           = clamp.value(leftEdge, rightEdge, x1);
+        final double computedResult2           = clamp.value(leftEdge, rightEdge, x2);
+        final double computedResult1Normalized = clamp.value(x1Normalized);
+        final double computedResult2Normalized = clamp.value(x2Normalized);
+
+        // Then
+        Assert.assertEquals(0, computedResult1, THRESHOLD);
+        Assert.assertEquals(1, computedResult2, THRESHOLD);
+        Assert.assertEquals(0, computedResult1Normalized, THRESHOLD);
+        Assert.assertEquals(1, computedResult2Normalized, THRESHOLD);
+        Assert.assertEquals(computedResult1, computedResult1Normalized, THRESHOLD);
+        Assert.assertEquals(computedResult2, computedResult2Normalized, THRESHOLD);
+    }
+
+    @Test
+    public void testClampFunction() {
+
+        // Given
+        final double leftEdge  = 5;
+        final double rightEdge = 10;
+        final double x        = 7;
+
+        final SmoothStepFactory.SmoothStepFunction clamp = SmoothStepFactory.getClamp();
+
+        // When
+        final double computedResult = clamp.value(leftEdge, rightEdge, x);
+
+        // Then
+        Assert.assertEquals(0.4, computedResult, THRESHOLD);
+
+    }
+
+    @Test
+    public void testCubicFunction() {
+
+        // Given
+        final double leftEdge  = 5;
+        final double rightEdge = 10;
+        final double x        = 7;
+
+        final SmoothStepFactory.SmoothStepFunction cubic = SmoothStepFactory.getCubic();
+
+        // When
+        final double computedResult = cubic.value(leftEdge, rightEdge, x);
+
+        // Then
+        Assert.assertEquals(0.352, computedResult, THRESHOLD);
+
+    }
+
+    @Test
+    public void testQuinticFunction() {
+
+        // Given
+        final double leftEdge  = 5;
+        final double rightEdge = 10;
+        final double x        = 7;
+
+        final SmoothStepFactory.SmoothStepFunction quintic = SmoothStepFactory.getQuintic();
+
+        // When
+        final double computedResult = quintic.value(leftEdge, rightEdge, x);
+
+        // Then
+        Assert.assertEquals(0.31744, computedResult, THRESHOLD);
+
+    }
+
+}

--- a/hipparchus-core/src/test/java/org/hipparchus/exception/LocalizedCoreFormatsTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/exception/LocalizedCoreFormatsTest.java
@@ -30,7 +30,7 @@ public class LocalizedCoreFormatsTest extends LocalizedFormatsAbstractTest {
 
     @Override
     protected int getExpectedNumber() {
-        return 183;
+        return 185;
     }
 
 }

--- a/hipparchus-core/src/test/java/org/hipparchus/linear/BlockRealMatrixTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/linear/BlockRealMatrixTest.java
@@ -21,9 +21,6 @@
  */
 package org.hipparchus.linear;
 
-import java.util.Arrays;
-import java.util.Random;
-
 import org.hipparchus.UnitTestUtils;
 import org.hipparchus.exception.LocalizedCoreFormats;
 import org.hipparchus.exception.MathIllegalArgumentException;
@@ -33,6 +30,9 @@ import org.hipparchus.random.Well1024a;
 import org.hipparchus.util.FastMath;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Random;
 
 /**
  * Test cases for the {@link BlockRealMatrix} class.
@@ -532,6 +532,36 @@ public final class BlockRealMatrixTest {
         } catch (MathIllegalArgumentException ex) {
             // ignored
         }
+    }
+
+    @Test
+    public void testArithmeticBlending() {
+
+        // Given
+        final RealMatrix m1 = new BlockRealMatrix(new double[][] {
+                { 1, 2, 3 },
+                { 4, 5, 6 },
+                { 7, 8, 9 },
+        });
+        final RealMatrix m2 = new BlockRealMatrix(new double[][] {
+                { 10, 11, 12 },
+                { 13, 14, 15 },
+                { 16, 17, 18 },
+        });
+
+        final double blendingValue = 0.2;
+
+        // When
+        final RealMatrix blendedMatrix = m1.blendArithmeticallyWith(m2, blendingValue);
+
+        // Then
+        final RealMatrix expectedMatrix = new BlockRealMatrix(new double[][] {
+                { 2.8, 3.8, 4.8 },
+                { 5.8, 6.8, 7.8 },
+                { 8.8, 9.8, 10.8 }
+        });
+
+        assertClose(expectedMatrix, blendedMatrix, normTolerance);
     }
 
     @Test
@@ -1374,4 +1404,3 @@ public final class BlockRealMatrixTest {
         return m;
     }
 }
-

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/Vector.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/Vector.java
@@ -21,16 +21,19 @@
  */
 package org.hipparchus.geometry;
 
-import java.text.NumberFormat;
-
+import org.hipparchus.analysis.polynomials.SmoothStepFactory;
+import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.MathRuntimeException;
+import org.hipparchus.util.Blendable;
+
+import java.text.NumberFormat;
 
 /** This interface represents a generic vector in a vectorial space or a point in an affine space.
  * @param <S> Type of the space.
  * @see Space
  * @see Point
  */
-public interface Vector<S extends Space> extends Point<S> {
+public interface Vector<S extends Space> extends Point<S>, Blendable<Vector<S>> {
 
     /** Get the null vector of the vectorial space or origin point of the affine space.
      * @return null vector of the vectorial space or origin point of the affine space
@@ -147,4 +150,10 @@ public interface Vector<S extends Space> extends Point<S> {
      */
     String toString(NumberFormat format);
 
+    @Override
+    default Vector<S> blendArithmeticallyWith(Vector<S> other, double blendingValue)
+            throws MathIllegalArgumentException {
+        SmoothStepFactory.checkBetweenZeroAndOneIncluded(blendingValue);
+        return this.scalarMultiply(1 - blendingValue).add(other.scalarMultiply(blendingValue));
+    }
 }

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/Vector.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/Vector.java
@@ -30,15 +30,16 @@ import java.text.NumberFormat;
 
 /** This interface represents a generic vector in a vectorial space or a point in an affine space.
  * @param <S> Type of the space.
+ * @param <V> Type of vector implementing this interface.
  * @see Space
  * @see Point
  */
-public interface Vector<S extends Space> extends Point<S>, Blendable<Vector<S>> {
+public interface Vector<S extends Space, V extends Vector<S,V>> extends Point<S>, Blendable<Vector<S,V>> {
 
     /** Get the null vector of the vectorial space or origin point of the affine space.
      * @return null vector of the vectorial space or origin point of the affine space
      */
-    Vector<S> getZero();
+    V getZero();
 
     /** Get the L<sub>1</sub> norm for the vector.
      * @return L<sub>1</sub> norm for the vector
@@ -64,44 +65,50 @@ public interface Vector<S extends Space> extends Point<S>, Blendable<Vector<S>> 
      * @param v vector to add
      * @return a new vector
      */
-    Vector<S> add(Vector<S> v);
+    V add(Vector<S,V> v);
 
     /** Add a scaled vector to the instance.
      * @param factor scale factor to apply to v before adding it
      * @param v vector to add
      * @return a new vector
      */
-    Vector<S> add(double factor, Vector<S> v);
+    V add(double factor, Vector<S,V> v);
 
     /** Subtract a vector from the instance.
      * @param v vector to subtract
      * @return a new vector
      */
-    Vector<S> subtract(Vector<S> v);
+    V subtract(Vector<S,V> v);
 
     /** Subtract a scaled vector from the instance.
      * @param factor scale factor to apply to v before subtracting it
      * @param v vector to subtract
      * @return a new vector
      */
-    Vector<S> subtract(double factor, Vector<S> v);
+    V subtract(double factor, Vector<S,V> v);
 
     /** Get the opposite of the instance.
      * @return a new vector which is opposite to the instance
      */
-    Vector<S> negate();
+    V negate();
 
     /** Get a normalized vector aligned with the instance.
      * @return a new normalized vector
      * @exception MathRuntimeException if the norm is zero
      */
-    Vector<S> normalize() throws MathRuntimeException;
+    default V normalize() throws MathRuntimeException{
+        double s = getNorm();
+        if (s == 0) {
+            throw new MathRuntimeException(LocalizedGeometryFormats.CANNOT_NORMALIZE_A_ZERO_NORM_VECTOR);
+        }
+        return scalarMultiply(1 / s);
+    }
 
     /** Multiply the instance by a scalar.
      * @param a scalar
      * @return a new vector
      */
-    Vector<S> scalarMultiply(double a);
+    V scalarMultiply(double a);
 
     /**
      * Returns true if any coordinate of this vector is infinite and none are NaN;
@@ -118,7 +125,7 @@ public interface Vector<S extends Space> extends Point<S>, Blendable<Vector<S>> 
      * @param v second vector
      * @return the distance between the instance and p according to the L<sub>1</sub> norm
      */
-    double distance1(Vector<S> v);
+    double distance1(Vector<S,V> v);
 
     /** Compute the distance between the instance and another vector according to the L<sub>&infin;</sub> norm.
      * <p>Calling this method is equivalent to calling:
@@ -127,7 +134,7 @@ public interface Vector<S extends Space> extends Point<S>, Blendable<Vector<S>> 
      * @param v second vector
      * @return the distance between the instance and p according to the L<sub>&infin;</sub> norm
      */
-    double distanceInf(Vector<S> v);
+    double distanceInf(Vector<S,V> v);
 
     /** Compute the square of the distance between the instance and another vector.
      * <p>Calling this method is equivalent to calling:
@@ -136,13 +143,13 @@ public interface Vector<S extends Space> extends Point<S>, Blendable<Vector<S>> 
      * @param v second vector
      * @return the square of the distance between the instance and p
      */
-    double distanceSq(Vector<S> v);
+    double distanceSq(Vector<S,V> v);
 
     /** Compute the dot-product of the instance and another vector.
      * @param v second vector
      * @return the dot product this.v
      */
-    double dotProduct(Vector<S> v);
+    double dotProduct(Vector<S,V> v);
 
     /** Get a string representation of this vector.
      * @param format the custom format for components
@@ -151,7 +158,7 @@ public interface Vector<S extends Space> extends Point<S>, Blendable<Vector<S>> 
     String toString(NumberFormat format);
 
     @Override
-    default Vector<S> blendArithmeticallyWith(Vector<S> other, double blendingValue)
+    default V blendArithmeticallyWith(Vector<S,V> other, double blendingValue)
             throws MathIllegalArgumentException {
         SmoothStepFactory.checkBetweenZeroAndOneIncluded(blendingValue);
         return this.scalarMultiply(1 - blendingValue).add(other.scalarMultiply(blendingValue));

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/VectorFormat.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/VectorFormat.java
@@ -45,8 +45,9 @@ import org.hipparchus.util.CompositeFormat;
  * to use a {@link NumberFormat} instance with disabled grouping in such a case.</p>
  *
  * @param <S> Type of the space.
+ * @param <V> Type of vector implementing Vector interface.
  */
-public abstract class VectorFormat<S extends Space> {
+public abstract class VectorFormat<S extends Space, V extends Vector<S,V>> {
 
     /** The default prefix: "{". */
     public static final String DEFAULT_PREFIX = "{";
@@ -172,7 +173,7 @@ public abstract class VectorFormat<S extends Space> {
      * @param vector the object to format.
      * @return a formatted string.
      */
-    public String format(Vector<S> vector) {
+    public String format(Vector<S, V> vector) {
         return format(vector, new StringBuffer(), new FieldPosition(0)).toString();
     }
 
@@ -184,7 +185,7 @@ public abstract class VectorFormat<S extends Space> {
      *            offsets of the alignment field
      * @return the value passed in as toAppendTo.
      */
-    public abstract StringBuffer format(Vector<S> vector,
+    public abstract StringBuffer format(Vector<S, V> vector,
                                         StringBuffer toAppendTo, FieldPosition pos);
 
     /**
@@ -226,7 +227,7 @@ public abstract class VectorFormat<S extends Space> {
      * @throws MathIllegalStateException if the beginning of the specified string
      * cannot be parsed.
      */
-    public abstract Vector<S> parse(String source) throws MathIllegalStateException;
+    public abstract Vector<S, V> parse(String source) throws MathIllegalStateException;
 
     /**
      * Parses a string to produce a {@link Vector} object.
@@ -234,7 +235,7 @@ public abstract class VectorFormat<S extends Space> {
      * @param pos input/output parsing parameter.
      * @return the parsed {@link Vector} object.
      */
-    public abstract Vector<S> parse(String source, ParsePosition pos);
+    public abstract Vector<S, V> parse(String source, ParsePosition pos);
 
     /**
      * Parses a string to produce an array of coordinates.

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/oned/OrientedPoint.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/oned/OrientedPoint.java
@@ -67,7 +67,7 @@ public class OrientedPoint implements Hyperplane<Euclidean1D> {
      * @param vector vector to check
      * @return offset of the vector
      */
-    public double getOffset(Vector<Euclidean1D> vector) {
+    public double getOffset(Vector<Euclidean1D, Vector1D> vector) {
         return getOffset((Point<Euclidean1D>) vector);
     }
 

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/oned/Vector1D.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/oned/Vector1D.java
@@ -28,8 +28,6 @@ import org.hipparchus.geometry.LocalizedGeometryFormats;
 import org.hipparchus.geometry.Point;
 import org.hipparchus.geometry.Space;
 import org.hipparchus.geometry.Vector;
-import org.hipparchus.geometry.euclidean.twod.Euclidean2D;
-import org.hipparchus.geometry.euclidean.twod.Vector2D;
 import org.hipparchus.util.FastMath;
 import org.hipparchus.util.MathUtils;
 

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/oned/Vector1D.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/oned/Vector1D.java
@@ -23,8 +23,6 @@ package org.hipparchus.geometry.euclidean.oned;
 
 import java.text.NumberFormat;
 
-import org.hipparchus.exception.MathRuntimeException;
-import org.hipparchus.geometry.LocalizedGeometryFormats;
 import org.hipparchus.geometry.Point;
 import org.hipparchus.geometry.Space;
 import org.hipparchus.geometry.Vector;
@@ -34,7 +32,7 @@ import org.hipparchus.util.MathUtils;
 /** This class represents a 1D vector.
  * <p>Instances of this class are guaranteed to be immutable.</p>
  */
-public class Vector1D implements Vector<Euclidean1D> {
+public class Vector1D implements Vector<Euclidean1D, Vector1D> {
 
     /** Origin (coordinates: 0). */
     public static final Vector1D ZERO = new Vector1D(0.0);
@@ -170,41 +168,32 @@ public class Vector1D implements Vector<Euclidean1D> {
 
     /** {@inheritDoc} */
     @Override
-    public Vector1D add(Vector<Euclidean1D> v) {
+    public Vector1D add(Vector<Euclidean1D, Vector1D> v) {
         Vector1D v1 = (Vector1D) v;
         return new Vector1D(x + v1.getX());
     }
 
     /** {@inheritDoc} */
     @Override
-    public Vector1D add(double factor, Vector<Euclidean1D> v) {
+    public Vector1D add(double factor, Vector<Euclidean1D, Vector1D> v) {
         Vector1D v1 = (Vector1D) v;
         return new Vector1D(x + factor * v1.getX());
     }
 
     /** {@inheritDoc} */
     @Override
-    public Vector1D subtract(Vector<Euclidean1D> p) {
+    public Vector1D subtract(Vector<Euclidean1D, Vector1D> p) {
         Vector1D p3 = (Vector1D) p;
         return new Vector1D(x - p3.x);
     }
 
     /** {@inheritDoc} */
     @Override
-    public Vector1D subtract(double factor, Vector<Euclidean1D> v) {
+    public Vector1D subtract(double factor, Vector<Euclidean1D, Vector1D> v) {
         Vector1D v1 = (Vector1D) v;
         return new Vector1D(x - factor * v1.getX());
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public Vector1D normalize() throws MathRuntimeException {
-        double s = getNorm();
-        if (s == 0) {
-            throw new MathRuntimeException(LocalizedGeometryFormats.CANNOT_NORMALIZE_A_ZERO_NORM_VECTOR);
-        }
-        return scalarMultiply(1 / s);
-    }
     /** {@inheritDoc} */
     @Override
     public Vector1D negate() {
@@ -231,7 +220,7 @@ public class Vector1D implements Vector<Euclidean1D> {
 
     /** {@inheritDoc} */
     @Override
-    public double distance1(Vector<Euclidean1D> p) {
+    public double distance1(Vector<Euclidean1D, Vector1D> p) {
         Vector1D p3 = (Vector1D) p;
         return FastMath.abs(p3.x - x);
     }
@@ -245,14 +234,14 @@ public class Vector1D implements Vector<Euclidean1D> {
 
     /** {@inheritDoc} */
     @Override
-    public double distanceInf(Vector<Euclidean1D> p) {
+    public double distanceInf(Vector<Euclidean1D, Vector1D> p) {
         Vector1D p3 = (Vector1D) p;
         return FastMath.abs(p3.x - x);
     }
 
     /** {@inheritDoc} */
     @Override
-    public double distanceSq(Vector<Euclidean1D> p) {
+    public double distanceSq(Vector<Euclidean1D, Vector1D> p) {
         Vector1D p3 = (Vector1D) p;
         final double dx = p3.x - x;
         return dx * dx;
@@ -260,7 +249,7 @@ public class Vector1D implements Vector<Euclidean1D> {
 
     /** {@inheritDoc} */
     @Override
-    public double dotProduct(final Vector<Euclidean1D> v) {
+    public double dotProduct(final Vector<Euclidean1D, Vector1D> v) {
         final Vector1D v1 = (Vector1D) v;
         return x * v1.x;
     }
@@ -397,12 +386,6 @@ public class Vector1D implements Vector<Euclidean1D> {
     @Override
     public String toString(final NumberFormat format) {
         return new Vector1DFormat(format).format(this);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Vector1D blendArithmeticallyWith(final Vector<Euclidean1D> other, final double blendingValue) {
-        return (Vector1D) Vector.super.blendArithmeticallyWith(other, blendingValue);
     }
 
 }

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/oned/Vector1D.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/oned/Vector1D.java
@@ -28,6 +28,8 @@ import org.hipparchus.geometry.LocalizedGeometryFormats;
 import org.hipparchus.geometry.Point;
 import org.hipparchus.geometry.Space;
 import org.hipparchus.geometry.Vector;
+import org.hipparchus.geometry.euclidean.twod.Euclidean2D;
+import org.hipparchus.geometry.euclidean.twod.Vector2D;
 import org.hipparchus.util.FastMath;
 import org.hipparchus.util.MathUtils;
 
@@ -397,6 +399,12 @@ public class Vector1D implements Vector<Euclidean1D> {
     @Override
     public String toString(final NumberFormat format) {
         return new Vector1DFormat(format).format(this);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Vector1D blendArithmeticallyWith(final Vector<Euclidean1D> other, final double blendingValue) {
+        return (Vector1D) Vector.super.blendArithmeticallyWith(other, blendingValue);
     }
 
 }

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/oned/Vector1DFormat.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/oned/Vector1DFormat.java
@@ -48,7 +48,7 @@ import org.hipparchus.util.CompositeFormat;
  * to use a {@link NumberFormat} instance with disabled grouping in such a case.</p>
  *
  */
-public class Vector1DFormat extends VectorFormat<Euclidean1D> {
+public class Vector1DFormat extends VectorFormat<Euclidean1D, Vector1D> {
 
     /**
      * Create an instance with default settings.
@@ -110,7 +110,7 @@ public class Vector1DFormat extends VectorFormat<Euclidean1D> {
 
     /** {@inheritDoc} */
     @Override
-    public StringBuffer format(final Vector<Euclidean1D> vector, final StringBuffer toAppendTo,
+    public StringBuffer format(final Vector<Euclidean1D, Vector1D> vector, final StringBuffer toAppendTo,
                                final FieldPosition pos) {
         final Vector1D p1 = (Vector1D) vector;
         return format(toAppendTo, pos, p1.getX());

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/threed/Line.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/threed/Line.java
@@ -186,7 +186,7 @@ public class Line implements Embedding<Euclidean3D, Euclidean1D> {
      * @return (n-1)-dimension point of the sub-space corresponding to
      * the specified space point
      */
-    public Vector1D toSubSpace(Vector<Euclidean3D> vector) {
+    public Vector1D toSubSpace(Vector<Euclidean3D, Vector3D> vector) {
         return toSubSpace((Point<Euclidean3D>) vector);
     }
 
@@ -195,7 +195,7 @@ public class Line implements Embedding<Euclidean3D, Euclidean1D> {
      * @return n-dimension point of the space corresponding to the
      * specified sub-space point
      */
-    public Vector3D toSpace(Vector<Euclidean1D> vector) {
+    public Vector3D toSpace(Vector<Euclidean1D, Vector1D> vector) {
         return toSpace((Point<Euclidean1D>) vector);
     }
 

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/threed/Plane.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/threed/Plane.java
@@ -253,7 +253,7 @@ public class Plane implements Hyperplane<Euclidean3D>, Embedding<Euclidean3D, Eu
      * @return (n-1)-dimension point of the sub-space corresponding to
      * the specified space point
      */
-    public Vector2D toSubSpace(Vector<Euclidean3D> vector) {
+    public Vector2D toSubSpace(Vector<Euclidean3D, Vector3D> vector) {
         return toSubSpace((Point<Euclidean3D>) vector);
     }
 
@@ -262,7 +262,7 @@ public class Plane implements Hyperplane<Euclidean3D>, Embedding<Euclidean3D, Eu
      * @return n-dimension point of the space corresponding to the
      * specified sub-space point
      */
-    public Vector3D toSpace(Vector<Euclidean2D> vector) {
+    public Vector3D toSpace(Vector<Euclidean2D, Vector2D> vector) {
         return toSpace((Point<Euclidean2D>) vector);
     }
 
@@ -473,7 +473,7 @@ public class Plane implements Hyperplane<Euclidean3D>, Embedding<Euclidean3D, Eu
      * @param vector vector to check
      * @return offset of the vector
      */
-    public double getOffset(Vector<Euclidean3D> vector) {
+    public double getOffset(Vector<Euclidean3D, Vector3D> vector) {
         return getOffset((Point<Euclidean3D>) vector);
     }
 

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/threed/Vector3D.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/threed/Vector3D.java
@@ -22,9 +22,6 @@
 
 package org.hipparchus.geometry.euclidean.threed;
 
-import java.io.Serializable;
-import java.text.NumberFormat;
-
 import org.hipparchus.exception.LocalizedCoreFormats;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.MathRuntimeException;
@@ -36,6 +33,10 @@ import org.hipparchus.util.FastMath;
 import org.hipparchus.util.MathArrays;
 import org.hipparchus.util.MathUtils;
 import org.hipparchus.util.SinCos;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.text.NumberFormat;
 
 /**
  * This class implements vectors in a three-dimensional space.
@@ -641,4 +642,9 @@ public class Vector3D implements Serializable, Vector<Euclidean3D> {
         return new Vector3DFormat(format).format(this);
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public Vector3D blendArithmeticallyWith(final Vector<Euclidean3D> other, final double blendingValue) {
+        return (Vector3D) Vector.super.blendArithmeticallyWith(other, blendingValue);
+    }
 }

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/threed/Vector3D.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/threed/Vector3D.java
@@ -25,7 +25,6 @@ package org.hipparchus.geometry.euclidean.threed;
 import org.hipparchus.exception.LocalizedCoreFormats;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.MathRuntimeException;
-import org.hipparchus.geometry.LocalizedGeometryFormats;
 import org.hipparchus.geometry.Point;
 import org.hipparchus.geometry.Space;
 import org.hipparchus.geometry.Vector;
@@ -41,7 +40,7 @@ import java.text.NumberFormat;
  * This class implements vectors in a three-dimensional space.
  * <p>Instance of this class are guaranteed to be immutable.</p>
  */
-public class Vector3D implements Serializable, Vector<Euclidean3D> {
+public class Vector3D implements Serializable, Vector<Euclidean3D, Vector3D> {
 
     /** Null vector (coordinates: 0, 0, 0). */
     public static final Vector3D ZERO   = new Vector3D(0, 0, 0);
@@ -286,38 +285,28 @@ public class Vector3D implements Serializable, Vector<Euclidean3D> {
 
     /** {@inheritDoc} */
     @Override
-    public Vector3D add(final Vector<Euclidean3D> v) {
+    public Vector3D add(final Vector<Euclidean3D, Vector3D> v) {
         final Vector3D v3 = (Vector3D) v;
         return new Vector3D(x + v3.x, y + v3.y, z + v3.z);
     }
 
     /** {@inheritDoc} */
     @Override
-    public Vector3D add(double factor, final Vector<Euclidean3D> v) {
+    public Vector3D add(double factor, final Vector<Euclidean3D, Vector3D> v) {
         return new Vector3D(1, this, factor, (Vector3D) v);
     }
 
     /** {@inheritDoc} */
     @Override
-    public Vector3D subtract(final Vector<Euclidean3D> v) {
+    public Vector3D subtract(final Vector<Euclidean3D, Vector3D> v) {
         final Vector3D v3 = (Vector3D) v;
         return new Vector3D(x - v3.x, y - v3.y, z - v3.z);
     }
 
     /** {@inheritDoc} */
     @Override
-    public Vector3D subtract(final double factor, final Vector<Euclidean3D> v) {
+    public Vector3D subtract(final double factor, final Vector<Euclidean3D, Vector3D> v) {
         return new Vector3D(1, this, -factor, (Vector3D) v);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Vector3D normalize() throws MathRuntimeException {
-        double s = getNorm();
-        if (s == 0) {
-            throw new MathRuntimeException(LocalizedGeometryFormats.CANNOT_NORMALIZE_A_ZERO_NORM_VECTOR);
-        }
-        return scalarMultiply(1 / s);
     }
 
     /** Get a vector orthogonal to the instance.
@@ -505,7 +494,7 @@ public class Vector3D implements Serializable, Vector<Euclidean3D> {
      * @see MathArrays#linearCombination(double, double, double, double, double, double)
      */
     @Override
-    public double dotProduct(final Vector<Euclidean3D> v) {
+    public double dotProduct(final Vector<Euclidean3D, Vector3D> v) {
         final Vector3D v3 = (Vector3D) v;
         return MathArrays.linearCombination(x, v3.x, y, v3.y, z, v3.z);
     }
@@ -514,7 +503,7 @@ public class Vector3D implements Serializable, Vector<Euclidean3D> {
      * @param v other vector
      * @return the cross product this ^ v as a new Vector3D
      */
-    public Vector3D crossProduct(final Vector<Euclidean3D> v) {
+    public Vector3D crossProduct(final Vector<Euclidean3D, Vector3D> v) {
         final Vector3D v3 = (Vector3D) v;
         return new Vector3D(MathArrays.linearCombination(y, v3.z, -z, v3.y),
                             MathArrays.linearCombination(z, v3.x, -x, v3.z),
@@ -523,7 +512,7 @@ public class Vector3D implements Serializable, Vector<Euclidean3D> {
 
     /** {@inheritDoc} */
     @Override
-    public double distance1(Vector<Euclidean3D> v) {
+    public double distance1(Vector<Euclidean3D, Vector3D> v) {
         final Vector3D v3 = (Vector3D) v;
         final double dx = FastMath.abs(v3.x - x);
         final double dy = FastMath.abs(v3.y - y);
@@ -543,7 +532,7 @@ public class Vector3D implements Serializable, Vector<Euclidean3D> {
 
     /** {@inheritDoc} */
     @Override
-    public double distanceInf(Vector<Euclidean3D> v) {
+    public double distanceInf(Vector<Euclidean3D, Vector3D> v) {
         final Vector3D v3 = (Vector3D) v;
         final double dx = FastMath.abs(v3.x - x);
         final double dy = FastMath.abs(v3.y - y);
@@ -553,7 +542,7 @@ public class Vector3D implements Serializable, Vector<Euclidean3D> {
 
     /** {@inheritDoc} */
     @Override
-    public double distanceSq(Vector<Euclidean3D> v) {
+    public double distanceSq(Vector<Euclidean3D, Vector3D> v) {
         final Vector3D v3 = (Vector3D) v;
         final double dx = v3.x - x;
         final double dy = v3.y - y;
@@ -641,9 +630,4 @@ public class Vector3D implements Serializable, Vector<Euclidean3D> {
         return new Vector3DFormat(format).format(this);
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public Vector3D blendArithmeticallyWith(final Vector<Euclidean3D> other, final double blendingValue) {
-        return (Vector3D) Vector.super.blendArithmeticallyWith(other, blendingValue);
-    }
 }

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/threed/Vector3D.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/threed/Vector3D.java
@@ -34,7 +34,6 @@ import org.hipparchus.util.MathArrays;
 import org.hipparchus.util.MathUtils;
 import org.hipparchus.util.SinCos;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.text.NumberFormat;
 

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/threed/Vector3DFormat.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/threed/Vector3DFormat.java
@@ -48,7 +48,7 @@ import org.hipparchus.util.CompositeFormat;
  * to use a {@link NumberFormat} instance with disabled grouping in such a case.</p>
  *
  */
-public class Vector3DFormat extends VectorFormat<Euclidean3D> {
+public class Vector3DFormat extends VectorFormat<Euclidean3D, Vector3D> {
 
     /**
      * Create an instance with default settings.
@@ -120,7 +120,7 @@ public class Vector3DFormat extends VectorFormat<Euclidean3D> {
      * @return the value passed in as toAppendTo.
      */
     @Override
-    public StringBuffer format(final Vector<Euclidean3D> vector, final StringBuffer toAppendTo,
+    public StringBuffer format(final Vector<Euclidean3D, Vector3D> vector, final StringBuffer toAppendTo,
                                final FieldPosition pos) {
         final Vector3D v3 = (Vector3D) vector;
         return format(toAppendTo, pos, v3.getX(), v3.getY(), v3.getZ());

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/twod/Line.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/twod/Line.java
@@ -230,7 +230,7 @@ public class Line implements Hyperplane<Euclidean2D>, Embedding<Euclidean2D, Euc
      * @return (n-1)-dimension point of the sub-space corresponding to
      * the specified space point
      */
-    public Vector1D toSubSpace(Vector<Euclidean2D> vector) {
+    public Vector1D toSubSpace(Vector<Euclidean2D, Vector2D> vector) {
         return toSubSpace((Point<Euclidean2D>) vector);
     }
 
@@ -239,7 +239,7 @@ public class Line implements Hyperplane<Euclidean2D>, Embedding<Euclidean2D, Euc
      * @return n-dimension point of the space corresponding to the
      * specified sub-space point
      */
-    public Vector2D toSpace(Vector<Euclidean1D> vector) {
+    public Vector2D toSpace(Vector<Euclidean1D, Vector1D> vector) {
         return toSpace((Point<Euclidean1D>) vector);
     }
 
@@ -326,7 +326,7 @@ public class Line implements Hyperplane<Euclidean2D>, Embedding<Euclidean2D, Euc
      * @param vector vector to check
      * @return offset of the vector
      */
-    public double getOffset(Vector<Euclidean2D> vector) {
+    public double getOffset(Vector<Euclidean2D, Vector2D> vector) {
         return getOffset((Point<Euclidean2D>) vector);
     }
 

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/twod/Vector2D.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/twod/Vector2D.java
@@ -30,6 +30,8 @@ import org.hipparchus.geometry.LocalizedGeometryFormats;
 import org.hipparchus.geometry.Point;
 import org.hipparchus.geometry.Space;
 import org.hipparchus.geometry.Vector;
+import org.hipparchus.geometry.euclidean.threed.Euclidean3D;
+import org.hipparchus.geometry.euclidean.threed.Vector3D;
 import org.hipparchus.util.FastMath;
 import org.hipparchus.util.MathArrays;
 import org.hipparchus.util.MathUtils;
@@ -555,6 +557,12 @@ public class Vector2D implements Vector<Euclidean2D> {
     @Override
     public String toString(final NumberFormat format) {
         return new Vector2DFormat(format).format(this);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Vector2D blendArithmeticallyWith(final Vector<Euclidean2D> other, final double blendingValue) {
+        return (Vector2D) Vector.super.blendArithmeticallyWith(other, blendingValue);
     }
 
 }

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/twod/Vector2D.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/twod/Vector2D.java
@@ -30,8 +30,6 @@ import org.hipparchus.geometry.LocalizedGeometryFormats;
 import org.hipparchus.geometry.Point;
 import org.hipparchus.geometry.Space;
 import org.hipparchus.geometry.Vector;
-import org.hipparchus.geometry.euclidean.threed.Euclidean3D;
-import org.hipparchus.geometry.euclidean.threed.Vector3D;
 import org.hipparchus.util.FastMath;
 import org.hipparchus.util.MathArrays;
 import org.hipparchus.util.MathUtils;

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/twod/Vector2D.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/twod/Vector2D.java
@@ -26,7 +26,6 @@ import java.text.NumberFormat;
 import org.hipparchus.exception.LocalizedCoreFormats;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.MathRuntimeException;
-import org.hipparchus.geometry.LocalizedGeometryFormats;
 import org.hipparchus.geometry.Point;
 import org.hipparchus.geometry.Space;
 import org.hipparchus.geometry.Vector;
@@ -37,7 +36,7 @@ import org.hipparchus.util.MathUtils;
 /** This class represents a 2D vector.
  * <p>Instances of this class are guaranteed to be immutable.</p>
  */
-public class Vector2D implements Vector<Euclidean2D> {
+public class Vector2D implements Vector<Euclidean2D, Vector2D> {
 
     /** Origin (coordinates: 0, 0). */
     public static final Vector2D ZERO   = new Vector2D(0, 0);
@@ -231,40 +230,30 @@ public class Vector2D implements Vector<Euclidean2D> {
 
     /** {@inheritDoc} */
     @Override
-    public Vector2D add(Vector<Euclidean2D> v) {
+    public Vector2D add(Vector<Euclidean2D, Vector2D> v) {
         Vector2D v2 = (Vector2D) v;
         return new Vector2D(x + v2.getX(), y + v2.getY());
     }
 
     /** {@inheritDoc} */
     @Override
-    public Vector2D add(double factor, Vector<Euclidean2D> v) {
+    public Vector2D add(double factor, Vector<Euclidean2D, Vector2D> v) {
         Vector2D v2 = (Vector2D) v;
         return new Vector2D(x + factor * v2.getX(), y + factor * v2.getY());
     }
 
     /** {@inheritDoc} */
     @Override
-    public Vector2D subtract(Vector<Euclidean2D> p) {
+    public Vector2D subtract(Vector<Euclidean2D, Vector2D> p) {
         Vector2D p3 = (Vector2D) p;
         return new Vector2D(x - p3.x, y - p3.y);
     }
 
     /** {@inheritDoc} */
     @Override
-    public Vector2D subtract(double factor, Vector<Euclidean2D> v) {
+    public Vector2D subtract(double factor, Vector<Euclidean2D, Vector2D> v) {
         Vector2D v2 = (Vector2D) v;
         return new Vector2D(x - factor * v2.getX(), y - factor * v2.getY());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Vector2D normalize() throws MathRuntimeException {
-        double s = getNorm();
-        if (s == 0) {
-            throw new MathRuntimeException(LocalizedGeometryFormats.CANNOT_NORMALIZE_A_ZERO_NORM_VECTOR);
-        }
-        return scalarMultiply(1 / s);
     }
 
     /** Compute the angular separation between two vectors.
@@ -327,7 +316,7 @@ public class Vector2D implements Vector<Euclidean2D> {
 
     /** {@inheritDoc} */
     @Override
-    public double distance1(Vector<Euclidean2D> p) {
+    public double distance1(Vector<Euclidean2D, Vector2D> p) {
         Vector2D p3 = (Vector2D) p;
         final double dx = FastMath.abs(p3.x - x);
         final double dy = FastMath.abs(p3.y - y);
@@ -345,7 +334,7 @@ public class Vector2D implements Vector<Euclidean2D> {
 
     /** {@inheritDoc} */
     @Override
-    public double distanceInf(Vector<Euclidean2D> p) {
+    public double distanceInf(Vector<Euclidean2D, Vector2D> p) {
         Vector2D p3 = (Vector2D) p;
         final double dx = FastMath.abs(p3.x - x);
         final double dy = FastMath.abs(p3.y - y);
@@ -354,7 +343,7 @@ public class Vector2D implements Vector<Euclidean2D> {
 
     /** {@inheritDoc} */
     @Override
-    public double distanceSq(Vector<Euclidean2D> p) {
+    public double distanceSq(Vector<Euclidean2D, Vector2D> p) {
         Vector2D p3 = (Vector2D) p;
         final double dx = p3.x - x;
         final double dy = p3.y - y;
@@ -363,7 +352,7 @@ public class Vector2D implements Vector<Euclidean2D> {
 
     /** {@inheritDoc} */
     @Override
-    public double dotProduct(final Vector<Euclidean2D> v) {
+    public double dotProduct(final Vector<Euclidean2D, Vector2D> v) {
         final Vector2D v2 = (Vector2D) v;
         return MathArrays.linearCombination(x, v2.x, y, v2.y);
     }
@@ -555,12 +544,6 @@ public class Vector2D implements Vector<Euclidean2D> {
     @Override
     public String toString(final NumberFormat format) {
         return new Vector2DFormat(format).format(this);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Vector2D blendArithmeticallyWith(final Vector<Euclidean2D> other, final double blendingValue) {
-        return (Vector2D) Vector.super.blendArithmeticallyWith(other, blendingValue);
     }
 
 }

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/twod/Vector2DFormat.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/euclidean/twod/Vector2DFormat.java
@@ -48,7 +48,7 @@ import org.hipparchus.util.CompositeFormat;
  * to use a {@link NumberFormat} instance with disabled grouping in such a case.</p>
  *
  */
-public class Vector2DFormat extends VectorFormat<Euclidean2D> {
+public class Vector2DFormat extends VectorFormat<Euclidean2D, Vector2D> {
 
     /**
      * Create an instance with default settings.
@@ -113,7 +113,7 @@ public class Vector2DFormat extends VectorFormat<Euclidean2D> {
 
     /** {@inheritDoc} */
     @Override
-    public StringBuffer format(final Vector<Euclidean2D> vector, final StringBuffer toAppendTo,
+    public StringBuffer format(final Vector<Euclidean2D, Vector2D> vector, final StringBuffer toAppendTo,
                                final FieldPosition pos) {
         final Vector2D p2 = (Vector2D) vector;
         return format(toAppendTo, pos, p2.getX(), p2.getY());

--- a/hipparchus-geometry/src/main/java/org/hipparchus/geometry/partitioning/AbstractRegion.java
+++ b/hipparchus-geometry/src/main/java/org/hipparchus/geometry/partitioning/AbstractRegion.java
@@ -320,11 +320,12 @@ public abstract class AbstractRegion<S extends Space, T extends Space> implement
 
     /** Check a point with respect to the region.
      * @param point point to check
+     * @param <V> type of vector implementing Vector interface
      * @return a code representing the point status: either {@link
      * Region.Location#INSIDE}, {@link Region.Location#OUTSIDE} or
      * {@link Region.Location#BOUNDARY}
      */
-    public Location checkPoint(final Vector<S> point) {
+    public <V extends Vector<S, V>> Location checkPoint(final Vector<S, V> point) {
         return checkPoint((Point<S>) point);
     }
 
@@ -337,11 +338,12 @@ public abstract class AbstractRegion<S extends Space, T extends Space> implement
     /** Check a point with respect to the region starting at a given node.
      * @param node root node of the region
      * @param point point to check
+     * @param <V> type of vector implementing Vector interface
      * @return a code representing the point status: either {@link
      * Region.Location#INSIDE INSIDE}, {@link Region.Location#OUTSIDE
      * OUTSIDE} or {@link Region.Location#BOUNDARY BOUNDARY}
      */
-    protected Location checkPoint(final BSPTree<S> node, final Vector<S> point) {
+    protected <V extends Vector<S, V>>  Location checkPoint(final BSPTree<S> node, final Vector<S, V> point) {
         return checkPoint(node, (Point<S>) point);
     }
 
@@ -411,8 +413,9 @@ public abstract class AbstractRegion<S extends Space, T extends Space> implement
 
     /** Set the barycenter of the instance.
      * @param barycenter barycenter of the instance
+     * @param <V> type of vector implementing Vector interface
      */
-    protected void setBarycenter(final Vector<S> barycenter) {
+    protected <V extends Vector<S, V>>  void setBarycenter(final Vector<S, V> barycenter) {
         setBarycenter((Point<S>) barycenter);
     }
 

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/oned/Vector1DFormatAbstractTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/oned/Vector1DFormatAbstractTest.java
@@ -51,15 +51,15 @@ public abstract class Vector1DFormatAbstractTest {
 
     @Test
     public void testDefaults() {
-        VectorFormat<Euclidean1D> vFormat = new VectorFormat<Euclidean1D>() {
-            public StringBuffer format(Vector<Euclidean1D> vector,
+        VectorFormat<Euclidean1D, Vector1D> vFormat = new VectorFormat<Euclidean1D, Vector1D>() {
+            public StringBuffer format(Vector<Euclidean1D, Vector1D> vector,
                                        StringBuffer toAppendTo, FieldPosition pos) {
                 return null;
             }
-            public Vector<Euclidean1D> parse(String source, ParsePosition parsePosition) {
+            public Vector<Euclidean1D, Vector1D> parse(String source, ParsePosition parsePosition) {
                 return null;
             }
-            public Vector<Euclidean1D> parse(String source) {
+            public Vector<Euclidean1D, Vector1D> parse(String source) {
                 return null;
             }
         };
@@ -72,15 +72,15 @@ public abstract class Vector1DFormatAbstractTest {
     @Test
     public void testNumberFormat() {
         NumberFormat nf = NumberFormat.getInstance(Locale.FRENCH);
-        VectorFormat<Euclidean1D> vFormat = new VectorFormat<Euclidean1D>(nf) {
-            public StringBuffer format(Vector<Euclidean1D> vector,
+        VectorFormat<Euclidean1D, Vector1D> vFormat = new VectorFormat<Euclidean1D, Vector1D>(nf) {
+            public StringBuffer format(Vector<Euclidean1D, Vector1D> vector,
                                        StringBuffer toAppendTo, FieldPosition pos) {
                 return null;
             }
-            public Vector<Euclidean1D> parse(String source, ParsePosition parsePosition) {
+            public Vector<Euclidean1D, Vector1D> parse(String source, ParsePosition parsePosition) {
                 return null;
             }
-            public Vector<Euclidean1D> parse(String source) {
+            public Vector<Euclidean1D, Vector1D> parse(String source) {
                 return null;
             }
         };
@@ -92,15 +92,15 @@ public abstract class Vector1DFormatAbstractTest {
 
     @Test
     public void testPrefixSuffixSeparator() {
-        VectorFormat<Euclidean1D> vFormat = new VectorFormat<Euclidean1D>("<", ">", "|") {
-            public StringBuffer format(Vector<Euclidean1D> vector,
+        VectorFormat<Euclidean1D, Vector1D> vFormat = new VectorFormat<Euclidean1D, Vector1D>("<", ">", "|") {
+            public StringBuffer format(Vector<Euclidean1D, Vector1D> vector,
                                        StringBuffer toAppendTo, FieldPosition pos) {
                 return null;
             }
-            public Vector<Euclidean1D> parse(String source, ParsePosition parsePosition) {
+            public Vector<Euclidean1D, Vector1D> parse(String source, ParsePosition parsePosition) {
                 return null;
             }
-            public Vector<Euclidean1D> parse(String source) {
+            public Vector<Euclidean1D, Vector1D> parse(String source) {
                 return null;
             }
         };

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/oned/Vector1DTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/oned/Vector1DTest.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.MathRuntimeException;
 import org.hipparchus.geometry.Space;
+import org.hipparchus.geometry.euclidean.threed.Vector3D;
 import org.hipparchus.geometry.euclidean.twod.FieldVector2D;
 import org.hipparchus.util.Decimal64Field;
 import org.hipparchus.util.FastMath;
@@ -234,6 +235,22 @@ public class Vector1DTest {
     @Test
     public void testNegate() {
         checkVector(new Vector1D(0.1).negate(), -0.1);
+    }
+
+    @Test
+    public void testArithmeticBlending() {
+
+        // Given
+        final Vector1D v1 = new Vector1D(1);
+        final Vector1D v2 = new Vector1D(2);
+
+        final double blendingValue = 0.7;
+
+        // When
+        final Vector1D blendedVector = v1.blendArithmeticallyWith(v2, blendingValue);
+
+        // Then
+        checkVector(blendedVector, 1.7);
     }
 
     private void checkVector(Vector1D v, double x) {

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/threed/PolyhedronsSetTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/threed/PolyhedronsSetTest.java
@@ -233,7 +233,7 @@ public class PolyhedronsSetTest {
                          1.0, c,
                          1.0, r.applyTo(barycenter.subtract(c)));
         Assert.assertEquals(0.0,
-                            newB.subtract((Vector<Euclidean3D>) tree.getBarycenter()).getNorm(),
+                            newB.subtract((Vector<Euclidean3D, Vector3D>) tree.getBarycenter()).getNorm(),
                             1.0e-10);
 
         final Vector3D[] expectedV = new Vector3D[] {

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/threed/Vector3DFormatAbstractTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/threed/Vector3DFormatAbstractTest.java
@@ -51,15 +51,15 @@ public abstract class Vector3DFormatAbstractTest {
 
     @Test
     public void testDefaults() {
-        VectorFormat<Euclidean3D> vFormat = new VectorFormat<Euclidean3D>() {
-            public StringBuffer format(Vector<Euclidean3D> vector,
+        VectorFormat<Euclidean3D, Vector3D> vFormat = new VectorFormat<Euclidean3D, Vector3D>() {
+            public StringBuffer format(Vector<Euclidean3D, Vector3D> vector,
                                        StringBuffer toAppendTo, FieldPosition pos) {
                 return null;
             }
-            public Vector<Euclidean3D> parse(String source, ParsePosition parsePosition) {
+            public Vector<Euclidean3D, Vector3D> parse(String source, ParsePosition parsePosition) {
                 return null;
             }
-            public Vector<Euclidean3D> parse(String source) {
+            public Vector<Euclidean3D, Vector3D> parse(String source) {
                 return null;
             }
         };
@@ -72,15 +72,15 @@ public abstract class Vector3DFormatAbstractTest {
     @Test
     public void testNumberFormat() {
         NumberFormat nf = NumberFormat.getInstance(Locale.FRENCH);
-        VectorFormat<Euclidean3D> vFormat = new VectorFormat<Euclidean3D>(nf) {
-            public StringBuffer format(Vector<Euclidean3D> vector,
+        VectorFormat<Euclidean3D, Vector3D> vFormat = new VectorFormat<Euclidean3D, Vector3D>(nf) {
+            public StringBuffer format(Vector<Euclidean3D, Vector3D> vector,
                                        StringBuffer toAppendTo, FieldPosition pos) {
                 return null;
             }
-            public Vector<Euclidean3D> parse(String source, ParsePosition parsePosition) {
+            public Vector<Euclidean3D, Vector3D> parse(String source, ParsePosition parsePosition) {
                 return null;
             }
-            public Vector<Euclidean3D> parse(String source) {
+            public Vector<Euclidean3D, Vector3D> parse(String source) {
                 return null;
             }
         };
@@ -92,15 +92,15 @@ public abstract class Vector3DFormatAbstractTest {
 
     @Test
     public void testPrefixSuffixSeparator() {
-        VectorFormat<Euclidean3D> vFormat = new VectorFormat<Euclidean3D>("<", ">", "|") {
-            public StringBuffer format(Vector<Euclidean3D> vector,
+        VectorFormat<Euclidean3D, Vector3D> vFormat = new VectorFormat<Euclidean3D, Vector3D>("<", ">", "|") {
+            public StringBuffer format(Vector<Euclidean3D, Vector3D> vector,
                                        StringBuffer toAppendTo, FieldPosition pos) {
                 return null;
             }
-            public Vector<Euclidean3D> parse(String source, ParsePosition parsePosition) {
+            public Vector<Euclidean3D, Vector3D> parse(String source, ParsePosition parsePosition) {
                 return null;
             }
-            public Vector<Euclidean3D> parse(String source) {
+            public Vector<Euclidean3D, Vector3D> parse(String source) {
                 return null;
             }
         };

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/threed/Vector3DTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/threed/Vector3DTest.java
@@ -31,6 +31,7 @@ import org.hipparchus.UnitTestUtils;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.MathRuntimeException;
 import org.hipparchus.geometry.Space;
+import org.hipparchus.geometry.Vector;
 import org.hipparchus.random.Well1024a;
 import org.hipparchus.util.FastMath;
 import org.hipparchus.util.Precision;
@@ -422,6 +423,22 @@ public class Vector3DTest {
             Vector3D cAccurate = new Vector3D(ux, uy, uz).crossProduct(new Vector3D(vx, vy, vz));
             Assert.assertEquals(0.0, cAccurate.distance(cNaive), 6.0e-15 * cAccurate.getNorm());
         }
+    }
+
+    @Test
+    public void testArithmeticBlending() {
+
+        // Given
+        final Vector3D v1 = new Vector3D(1,2,3);
+        final Vector3D v2 = new Vector3D(4,5,6);
+
+        final double blendingValue = 0.7;
+
+        // When
+        final Vector3D blendedVector = v1.blendArithmeticallyWith(v2, blendingValue);
+
+        // Then
+        checkVector(blendedVector, 3.1, 4.1, 5.1);
     }
 
     private void checkVector(Vector3D v, double x, double y, double z) {

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/twod/Vector2DFormatAbstractTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/twod/Vector2DFormatAbstractTest.java
@@ -51,15 +51,15 @@ public abstract class Vector2DFormatAbstractTest {
 
     @Test
     public void testDefaults() {
-        VectorFormat<Euclidean2D> vFormat = new VectorFormat<Euclidean2D>() {
-            public StringBuffer format(Vector<Euclidean2D> vector,
+        VectorFormat<Euclidean2D, Vector2D> vFormat = new VectorFormat<Euclidean2D, Vector2D>() {
+            public StringBuffer format(Vector<Euclidean2D, Vector2D> vector,
                                        StringBuffer toAppendTo, FieldPosition pos) {
                 return null;
             }
-            public Vector<Euclidean2D> parse(String source, ParsePosition parsePosition) {
+            public Vector<Euclidean2D, Vector2D> parse(String source, ParsePosition parsePosition) {
                 return null;
             }
-            public Vector<Euclidean2D> parse(String source) {
+            public Vector<Euclidean2D, Vector2D> parse(String source) {
                 return null;
             }
         };
@@ -72,15 +72,15 @@ public abstract class Vector2DFormatAbstractTest {
     @Test
     public void testNumberFormat() {
         NumberFormat nf = NumberFormat.getInstance(Locale.FRENCH);
-        VectorFormat<Euclidean2D> vFormat = new VectorFormat<Euclidean2D>(nf) {
-            public StringBuffer format(Vector<Euclidean2D> vector,
+        VectorFormat<Euclidean2D, Vector2D> vFormat = new VectorFormat<Euclidean2D, Vector2D>(nf) {
+            public StringBuffer format(Vector<Euclidean2D, Vector2D> vector,
                                        StringBuffer toAppendTo, FieldPosition pos) {
                 return null;
             }
-            public Vector<Euclidean2D> parse(String source, ParsePosition parsePosition) {
+            public Vector<Euclidean2D, Vector2D> parse(String source, ParsePosition parsePosition) {
                 return null;
             }
-            public Vector<Euclidean2D> parse(String source) {
+            public Vector<Euclidean2D, Vector2D> parse(String source) {
                 return null;
             }
         };
@@ -92,15 +92,15 @@ public abstract class Vector2DFormatAbstractTest {
 
     @Test
     public void testPrefixSuffixSeparator() {
-        VectorFormat<Euclidean2D> vFormat = new VectorFormat<Euclidean2D>("<", ">", "|") {
-            public StringBuffer format(Vector<Euclidean2D> vector,
+        VectorFormat<Euclidean2D, Vector2D> vFormat = new VectorFormat<Euclidean2D, Vector2D>("<", ">", "|") {
+            public StringBuffer format(Vector<Euclidean2D, Vector2D> vector,
                                        StringBuffer toAppendTo, FieldPosition pos) {
                 return null;
             }
-            public Vector<Euclidean2D> parse(String source, ParsePosition parsePosition) {
+            public Vector<Euclidean2D, Vector2D> parse(String source, ParsePosition parsePosition) {
                 return null;
             }
-            public Vector<Euclidean2D> parse(String source) {
+            public Vector<Euclidean2D, Vector2D> parse(String source) {
                 return null;
             }
         };

--- a/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/twod/Vector2DTest.java
+++ b/hipparchus-geometry/src/test/java/org/hipparchus/geometry/euclidean/twod/Vector2DTest.java
@@ -28,6 +28,7 @@ import org.hipparchus.exception.LocalizedCoreFormats;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.MathRuntimeException;
 import org.hipparchus.geometry.LocalizedGeometryFormats;
+import org.hipparchus.geometry.euclidean.oned.Vector1D;
 import org.hipparchus.util.Decimal64Field;
 import org.hipparchus.util.FastMath;
 import org.hipparchus.util.SinCos;
@@ -277,6 +278,22 @@ public class Vector2DTest {
                                                  new Vector2D(1, 0),
                                                  new Vector2D(2, 0)),
                             1.0e-15);
+    }
+
+    @Test
+    public void testArithmeticBlending() {
+
+        // Given
+        final Vector2D v1 = new Vector2D(1,2);
+        final Vector2D v2 = new Vector2D(3,4);
+
+        final double blendingValue = 0.7;
+
+        // When
+        final Vector2D blendedVector = v1.blendArithmeticallyWith(v2, blendingValue);
+
+        // Then
+        check(blendedVector, 2.4, 3.4, 1e-12);
     }
 
     private void check(final Vector2D v, final double x, final double y, final double tol) {

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -49,6 +49,12 @@ If the output is not quite correct, check for invisible trailing spaces!
     <title>Hipparchus Release Notes</title>
   </properties>
   <body>
+    <release version="2.4" date="TBA" description="This is a maintenance release.">
+      <action dev="vincent" type="add" issue="issues/212">
+          Added Blendable interface and its implementation in RealMatrix and Vector interfaces.
+          Added SmoothStepFactory which allow for quick creation of common and generic smoothstep function.
+      </action>
+    </release>
     <release version="2.3" date="2022-10-05" description="This is a maintenance release.">
       <action dev="luc" type="fix" issue="issues/208">
         Fixed wrong negation of point on the 2-sphere.

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -51,8 +51,8 @@ If the output is not quite correct, check for invisible trailing spaces!
   <body>
     <release version="2.4" date="TBA" description="This is a maintenance release.">
       <action dev="vincent" type="add" issue="issues/212">
-          Added Blendable interface and its implementation in RealMatrix and Vector interfaces.
-          Added SmoothStepFactory which allow for quick creation of common and generic smoothstep function.
+        Added Blendable interface and its implementation in RealMatrix and Vector interfaces.
+        Added SmoothStepFactory which allow for quick creation of common and generic smoothstep function.
       </action>
     </release>
     <release version="2.3" date="2022-10-05" description="This is a maintenance release.">


### PR DESCRIPTION
Hi everyone,

This pull request aims to close the issue #212.

Please find below simple UML diagrams that show what has been done : 

## Note on ```SmoothStepFactory``` class
![UMLDiagramSmoothSteps](https://user-images.githubusercontent.com/111506831/197553547-85b151f4-ccbc-418a-ba4a-007657442f01.png)
As you can see in this diagram, the user cannot directly create a ```SmoothStepFunction``` and must use a ```SmoothStepFactory``` which offers static access to commonly used smoothstep as well as a general method for general order 2N + 1. The ```SmoothStepFunction``` extends ```PolynomialFunction``` and is a nested class of ```SmoothStepFactory``` so that only this class has access to its constructor.

## Note on ```Blendable``` interface
![UMLDiagramBlending](https://user-images.githubusercontent.com/111506831/197546182-38dd31ed-6635-4bbd-9209-4e590c25f980.png)
This interface currently has only one method named "blendArithmeticallyWith" and has implementation in ```RealMatrix``` and ```Vector```. 

Note that in the ```Vector``` class case, I had to override the default method for each inheritor of  the ```Vector``` interface. Indeed, it is not implemented by an ```AbstractVector```(contrary to ```RealMatrix```) nor do its methods return a V extends Vector<S,V> but a Vector\<S> instead.

I limited code duplication as much as I think is possible but i you find another way to do it, please tell me. For now, the overriding methods in  ```Vector1D```, ```Vector2D``` and ```Vector3D``` are only casting the output to themselves.