### PR TITLE
Issue 239: matrixExponential giving NaN results

### DIFF
--- a/hipparchus-core/src/main/java/org/hipparchus/linear/MatrixUtils.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/linear/MatrixUtils.java
@@ -1239,12 +1239,10 @@ public class MatrixUtils {
                     rm.getRowDimension(), rm.getColumnDimension());
         }
 
-        // Preprocessing to reduce the norm
+        // Copy input matrix
         int dim = rm.getRowDimension();
         final RealMatrix identity = MatrixUtils.createRealIdentityMatrix(dim);
-        final double preprocessScale = rm.getTrace() / dim;
         RealMatrix scaledMatrix = rm.copy();
-        scaledMatrix = scaledMatrix.subtract(identity.scalarMultiply(preprocessScale));
 
         // Select pade degree required
         final double l1Norm = rm.getNorm1();
@@ -1268,12 +1266,7 @@ public class MatrixUtils {
 
             // Scale matrix by power of 2
             final int finalSquaringCount = squaringCount;
-            scaledMatrix.walkInOptimizedOrder(new DefaultRealMatrixChangingVisitor() {
-                @Override
-                public double visit(int row, int column, double value) {
-                    return Math.scalb(value, -finalSquaringCount);
-                }
-            });
+            scaledMatrix.mapToSelf(x -> Math.scalb(x, -finalSquaringCount));
         }
 
         // Calculate U and V using Horner
@@ -1308,9 +1301,6 @@ public class MatrixUtils {
         for (int i = 0; i < squaringCount; i++) {
             result = result.multiply(result);
         }
-
-        // Undo preprocessing
-        result = result.scalarMultiply(Math.exp(preprocessScale));
 
         return result;
     }

--- a/hipparchus-core/src/test/java/org/hipparchus/linear/MatrixUtilsTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/linear/MatrixUtilsTest.java
@@ -646,6 +646,22 @@ public final class MatrixUtilsTest {
 
         UnitTestUtils.assertEquals("matrixExponential pade13-2 incorrect result",
                 expectedResult2, MatrixUtils.matrixExponential(exponent2), 65536.0 * Math.ulp(1e8));
+
+
+        double[][] exponentArr3 = {
+                {-1e4, 1e4},
+                {1.0, -1.0}
+        };
+        RealMatrix exponent3 = MatrixUtils.createRealMatrix(exponentArr3);
+
+        double[][] expectedResultArr3 = {
+                {9.99900009999e-05, 0.999900009999},
+                {9.99900009999e-05, 0.999900009999}
+        };
+        RealMatrix expectedResult3 = MatrixUtils.createRealMatrix(expectedResultArr3);
+
+        UnitTestUtils.assertEquals("matrixExponential pade13-3 incorrect result",
+                expectedResult3, MatrixUtils.matrixExponential(exponent3), 4096.0 * Math.ulp(1.0));
     }
 
     @Test


### PR DESCRIPTION
A matrix with large norm caused numerical issues with the matrixExponential preprocessing step.
I've simply removed the preprocessing.  I'm not sure if that is going to cause issues elsewhere, but the tests still pass unchanged.
I have added an extra test for a large norm matrix.