### PR TITLE
Issue-263: Created a rule to forbid Python keywords in method names.

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -50,6 +50,9 @@ If the output is not quite correct, check for invisible trailing spaces!
   </properties>
   <body>
     <release version="3.0" date="TBD" description="This is a major release.">
+      <action dev="maxime" type="add" issue="issues/263">
+        Created a rule to forbid Python keywords in method, class, interface and enum names.
+      </action>
       <action dev="luc" type="fix" issue="issues/262">
         Fixed determinant computation in eigen decomposition with complex eigenvalues.
       </action>

--- a/src/conf/checkstyle.xml
+++ b/src/conf/checkstyle.xml
@@ -144,6 +144,14 @@
 
     <!-- Check if @Override tags are present  -->
     <module name="MissingOverride" />
+    
+    <!-- Avoid Python keywords in method, class, interface and enum names -->
+    <module name="IllegalIdentifierName">
+        <property name="format"
+                  value="(?i)^(?!(del|elif|except|from|global|in|is|lambda|nonlocal|not|or|pass|raise|with|yield)$).+$"/>
+        <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, METHOD_DEF, ENUM_DEF"/>
+        <message key="name.invalidPattern" value="Name ''{0}'' is not allowed."/>
+    </module>
 
     <!-- <module name="TodoComment" /> -->
 


### PR DESCRIPTION
Only checkstyle was modified, no code modification was needed.
Closes #263
