### PR TITLE
Fixes 256: rework interfaces in (Field) Derivatives

### DIFF
--- a/hipparchus-core/src/changes/changes.xml
+++ b/hipparchus-core/src/changes/changes.xml
@@ -49,12 +49,15 @@ If the output is not quite correct, check for invisible trailing spaces!
     <title>Hipparchus Core Release Notes</title>
   </properties>
   <body>
-    <release version="3.1" date="TBD" description="TBD.">
+    <release version="3.1" date="TBD" description="TBD.">$
+      <action dev="serrof" type="update" issue="issues/286">
+        Rework interfaces for Derivative and FieldDerivative.
+      </action>
       <action dev="serrof" type="add" issue="issues/281">
         Add default implementations in CalculusFieldElement and inheritors.
       </action>
       <action dev="serrof" type="add" issue="issues/280">
-        Add square method to FieldElement.
+        Add square method to CalculusFieldElement.
       </action>
     </release>
     <release version="3.0" date="2023-10-08" description="This is a major release.">

--- a/hipparchus-core/src/main/java/org/hipparchus/CalculusFieldElement.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/CalculusFieldElement.java
@@ -121,7 +121,9 @@ public interface CalculusFieldElement<T extends FieldElement<T>> extends FieldEl
      * @return ulp(this)
      * @since 2.0
      */
-    T ulp();
+    default T ulp() {
+        return newInstance(FastMath.ulp(getReal()));
+    }
 
     /**
      * Returns the hypotenuse of a triangle with sides {@code this} and {@code y}
@@ -168,8 +170,10 @@ public interface CalculusFieldElement<T extends FieldElement<T>> extends FieldEl
         return pow(1. / n);
     }
 
-    /** {@inheritDoc} */
-    @Override
+    /** Compute this &times; this.
+     * @return a new element representing this &times; this
+     * @since 3.1
+     */
     default T square() {
         return pow(2);
     }
@@ -465,17 +469,23 @@ public interface CalculusFieldElement<T extends FieldElement<T>> extends FieldEl
     /** Get the smallest whole number larger than instance.
      * @return ceil(this)
      */
-    T ceil();
+    default T ceil() {
+        return newInstance(FastMath.ceil(getReal()));
+    }
 
     /** Get the largest whole number smaller than instance.
      * @return floor(this)
      */
-    T floor();
+    default T floor() {
+        return newInstance(FastMath.floor(getReal()));
+    }
 
     /** Get the whole number that is the nearest to the instance, or the even one if x is exactly half way between two integers.
      * @return a double number r such that r is an integer r - 0.5 &le; this &le; r + 0.5
      */
-    T rint();
+    default T rint() {
+        return newInstance(FastMath.rint(getReal()));
+    }
 
     /** IEEE remainder operator.
      * @param a right hand side parameter of the operator
@@ -495,7 +505,9 @@ public interface CalculusFieldElement<T extends FieldElement<T>> extends FieldEl
      * with special handling for 0 and NaN)
      * @return -1.0, -0.0, +0.0, +1.0 or NaN depending on sign of a
      */
-    T sign();
+    default T sign() {
+        return newInstance(FastMath.signum(getReal()));
+    }
 
     /**
      * Returns the instance with the sign of the argument.

--- a/hipparchus-core/src/main/java/org/hipparchus/FieldElement.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/FieldElement.java
@@ -74,12 +74,6 @@ public interface FieldElement<T extends FieldElement<T>> {
      */
     T multiply(T a) throws NullArgumentException;
 
-    /** Compute this &times; this.
-     * @return a new element representing this &times; this
-     * @since 3.1
-     */
-    T square() throws NullArgumentException;
-
     /** Compute this &divide; a.
      * @param a element to divide by
      * @return a new element representing this &divide; a

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/Derivative.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/Derivative.java
@@ -24,7 +24,7 @@ import org.hipparchus.util.FastMath;
  * @param <T> the type of the field elements
  * @since 1.7
  */
-public interface Derivative<T extends CalculusFieldElement<T>> extends CalculusFieldElement<T> {
+public interface Derivative<T extends CalculusFieldElement<T>> extends CalculusFieldElement<T>, DifferentialAlgebra {
 
     /** {@inheritDoc} */
     @Override
@@ -32,20 +32,25 @@ public interface Derivative<T extends CalculusFieldElement<T>> extends CalculusF
         return getValue();
     }
 
-    /** Get the number of free parameters.
-     * @return number of free parameters
-     */
-    int getFreeParameters();
-
-    /** Get the derivation order.
-     * @return derivation order
-     */
-    int getOrder();
-
     /** Get the value part of the function.
      * @return value part of the value of the function
      */
     double getValue();
+
+    /** Create a new object with new value (zeroth-order derivative, as passed as input)
+     * and same derivatives of order one and above.
+     * <p>
+     * This default implementation is there so that no API gets broken
+     * by the next release, which is not a major one. Custom inheritors
+     * should probably overwrite it.
+     * </p>
+     * @param value zeroth-order derivative of new represented function
+     * @return new object with changed value
+     * @since 3.1
+     */
+    default T withValue(double value) {
+        return add(newInstance(value - getValue()));
+    }
 
     /** Get a partial derivative.
      * @param orders derivation orders with respect to each variable (if all orders are 0,
@@ -59,6 +64,18 @@ public interface Derivative<T extends CalculusFieldElement<T>> extends CalculusF
      */
     double getPartialDerivative(int ... orders)
         throws MathIllegalArgumentException;
+
+    /** {@inheritDoc} */
+    @Override
+    default T add(double a) {
+        return withValue(getValue() + a);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T subtract(double a) {
+        return withValue(getValue() - a);
+    }
 
     /** Compute composition of the instance by a univariate function.
      * @param f array of value and derivatives of the function at
@@ -103,37 +120,13 @@ public interface Derivative<T extends CalculusFieldElement<T>> extends CalculusF
 
     /** {@inheritDoc} */
     @Override
-    default T ceil() {
-        return newInstance(FastMath.ceil(getValue()));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    default T floor() {
-        return newInstance(FastMath.floor(getValue()));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    default T rint() {
-        return newInstance(FastMath.rint(getValue()));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    default T ulp() {
-        return newInstance(FastMath.ulp(getValue()));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    default T sign() {
-        return newInstance(FastMath.signum(getValue()));
-    }
-
-    /** {@inheritDoc} */
-    @Override
     default int getExponent() {
         return FastMath.getExponent(getValue());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T remainder(double a) {
+        return withValue(FastMath.IEEEremainder(getValue(), a));
     }
 }

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/Derivative1.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/Derivative1.java
@@ -1,0 +1,206 @@
+package org.hipparchus.analysis.differentiation;
+
+import org.hipparchus.CalculusFieldElement;
+import org.hipparchus.util.FastMath;
+import org.hipparchus.util.SinCos;
+import org.hipparchus.util.SinhCosh;
+import org.hipparchus.util.FieldSinCos;
+import org.hipparchus.util.FieldSinhCosh;
+
+/** Interface representing an object holding partial derivatives up to first order.
+ * @param <T> the type of the field elements
+ * @see Derivative
+ * @see UnivariateDerivative1
+ * @see Gradient
+ * @see SparseGradient
+ * @since 3.1
+ */
+public interface Derivative1<T extends CalculusFieldElement<T>> extends Derivative<T> {
+
+    /** {@inheritDoc} */
+    @Override
+    default int getOrder() {
+        return 1;
+    }
+
+    /** Compute composition of the instance by a univariate function differentiable at order 1.
+     * @param f0 value of function
+     * @param f1 first-order derivative
+     * @return f(this)
+     */
+    T compose(double f0, double f1);
+
+    /** {@inheritDoc} */
+    @Override
+    default T square() {
+        final double f0 = getValue();
+        return compose(f0 * f0, 2 * f0);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T reciprocal () {
+        final double inv1 = 1.0 / getValue();
+        final double inv2 = -inv1 * inv1;
+        return compose(inv1, inv2);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T sqrt() {
+        final double s = FastMath.sqrt(getValue());
+        return compose(s, 1 / (2 * s));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T cbrt() {
+        final double c = FastMath.cbrt(getValue());
+        return compose(c, 1 / (3 * c * c));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T rootN(int n) {
+        if (n == 2) {
+            return sqrt();
+        } else if (n == 3) {
+            return cbrt();
+        } else {
+            final double r = FastMath.pow(getValue(), 1.0 / n);
+            return compose(r, 1 / (n * FastMath.pow(r, n - 1)));
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T exp() {
+        final double exp = FastMath.exp(getValue());
+        return compose(exp, exp);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T expm1() {
+        final double exp   = FastMath.exp(getValue());
+        final double expM1 = FastMath.expm1(getValue());
+        return compose(expM1, exp);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T log() {
+        return compose(FastMath.log(getValue()), 1 / getValue());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T log1p() {
+        return compose(FastMath.log1p(getValue()), 1 / (1 + getValue()));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T log10() {
+        return compose(FastMath.log10(getValue()), 1 / (getValue() * FastMath.log(10.0)));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T cos() {
+        final SinCos sinCos = FastMath.sinCos(getValue());
+        return compose(sinCos.cos(), -sinCos.sin());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T sin() {
+        final SinCos sinCos = FastMath.sinCos(getValue());
+        return compose(sinCos.sin(), sinCos.cos());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default FieldSinCos<T> sinCos() {
+        final SinCos sinCos = FastMath.sinCos(getValue());
+        return new FieldSinCos<>(compose(sinCos.sin(), sinCos.cos()),
+                compose(sinCos.cos(), -sinCos.sin()));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T tan() {
+        final double tan = FastMath.tan(getValue());
+        return compose(tan, 1 + tan * tan);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T acos() {
+        final double f0 = getValue();
+        return compose(FastMath.acos(f0), -1 / FastMath.sqrt(1 - f0 * f0));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T asin() {
+        final double f0 = getValue();
+        return compose(FastMath.asin(f0), 1 / FastMath.sqrt(1 - f0 * f0));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T atan() {
+        final double f0 = getValue();
+        return compose(FastMath.atan(f0), 1 / (1 + f0 * f0));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T cosh() {
+        return compose(FastMath.cosh(getValue()), FastMath.sinh(getValue()));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T sinh() {
+        return compose(FastMath.sinh(getValue()), FastMath.cosh(getValue()));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default FieldSinhCosh<T> sinhCosh() {
+        final SinhCosh sinhCosh = FastMath.sinhCosh(getValue());
+        return new FieldSinhCosh<>(compose(sinhCosh.sinh(), sinhCosh.cosh()),
+                compose(sinhCosh.cosh(), sinhCosh.sinh()));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T tanh() {
+        final double tanh = FastMath.tanh(getValue());
+        return compose(tanh, 1 - tanh * tanh);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T acosh() {
+        final double f0 = getValue();
+        return compose(FastMath.acosh(f0), 1 / FastMath.sqrt(f0 * f0 - 1));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T asinh() {
+        final double f0 = getValue();
+        return compose(FastMath.asinh(f0), 1 / FastMath.sqrt(f0 * f0 + 1));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T atanh() {
+        final double f0 = getValue();
+        return compose(FastMath.atanh(f0), 1 / (1 - f0 * f0));
+    }
+
+}

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/DerivativeStructure.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/DerivativeStructure.java
@@ -97,6 +97,15 @@ public class DerivativeStructure implements Derivative<DerivativeStructure>, Ser
         return factory.constant(value);
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public DerivativeStructure withValue(final double value) {
+        final DerivativeStructure ds = factory.build();
+        System.arraycopy(data, 1, ds.data, 1, data.length - 1);
+        ds.data[0] = value;
+        return ds;
+    }
+
     /** Get the factory that built the instance.
      * @return factory that built the instance
      */
@@ -104,14 +113,14 @@ public class DerivativeStructure implements Derivative<DerivativeStructure>, Ser
         return factory;
     }
 
-    @Override
     /** {@inheritDoc} */
+    @Override
     public int getFreeParameters() {
         return getFactory().getCompiler().getFreeParameters();
     }
 
-    @Override
     /** {@inheritDoc} */
+    @Override
     public int getOrder() {
         return getFactory().getCompiler().getOrder();
     }
@@ -171,16 +180,6 @@ public class DerivativeStructure implements Derivative<DerivativeStructure>, Ser
     }
 
     /** {@inheritDoc}
-     */
-    @Override
-    public DerivativeStructure add(final double a) {
-        final DerivativeStructure ds = factory.build();
-        System.arraycopy(data, 0, ds.data, 0, data.length);
-        ds.data[0] += a;
-        return ds;
-    }
-
-    /** {@inheritDoc}
      * @exception MathIllegalArgumentException if number of free parameters
      * or orders do not match
      */
@@ -191,13 +190,6 @@ public class DerivativeStructure implements Derivative<DerivativeStructure>, Ser
         final DerivativeStructure ds = factory.build();
         factory.getCompiler().add(data, 0, a.data, 0, ds.data, 0);
         return ds;
-    }
-
-    /** {@inheritDoc}
-     */
-    @Override
-    public DerivativeStructure subtract(final double a) {
-        return add(-a);
     }
 
     /** {@inheritDoc}
@@ -268,15 +260,6 @@ public class DerivativeStructure implements Derivative<DerivativeStructure>, Ser
         return result;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public DerivativeStructure remainder(final double a) {
-        final DerivativeStructure ds = factory.build();
-        System.arraycopy(data, 0, ds.data, 0, data.length);
-        ds.data[0] = FastMath.IEEEremainder(ds.data[0], a);
-        return ds;
-    }
-
     /** {@inheritDoc}
      * @exception MathIllegalArgumentException if number of free parameters
      * or orders do not match
@@ -315,34 +298,6 @@ public class DerivativeStructure implements Derivative<DerivativeStructure>, Ser
     /** {@inheritDoc}
      */
     @Override
-    public DerivativeStructure ceil() {
-        return factory.constant(FastMath.ceil(data[0]));
-    }
-
-    /** {@inheritDoc}
-     */
-    @Override
-    public DerivativeStructure floor() {
-        return factory.constant(FastMath.floor(data[0]));
-    }
-
-    /** {@inheritDoc}
-     */
-    @Override
-    public DerivativeStructure rint() {
-        return factory.constant(FastMath.rint(data[0]));
-    }
-
-    /** {@inheritDoc}
-     */
-    @Override
-    public DerivativeStructure sign() {
-        return factory.constant(FastMath.signum(data[0]));
-    }
-
-    /** {@inheritDoc}
-     */
-    @Override
     public DerivativeStructure copySign(final DerivativeStructure sign) {
         long m = Double.doubleToLongBits(data[0]);
         long s = Double.doubleToLongBits(sign.data[0]);
@@ -372,19 +327,6 @@ public class DerivativeStructure implements Derivative<DerivativeStructure>, Ser
         for (int i = 0; i < ds.data.length; ++i) {
             ds.data[i] = FastMath.scalb(data[i], n);
         }
-        return ds;
-    }
-
-    /** {@inheritDoc}
-     * <p>
-     * The {@code ulp} function is a step function, hence all its derivatives are 0.
-     * </p>
-     * @since 2.0
-     */
-    @Override
-    public DerivativeStructure ulp() {
-        final DerivativeStructure ds = factory.build();
-        ds.data[0] = FastMath.ulp(data[0]);
         return ds;
     }
 

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/DifferentialAlgebra.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/DifferentialAlgebra.java
@@ -1,0 +1,22 @@
+package org.hipparchus.analysis.differentiation;
+
+/** Interface representing an object holding partial derivatives.
+ * @see Derivative
+ * @see TaylorMap
+ * @see FieldDerivative
+ * @see FieldTaylorMap
+ * @since 3.1
+ */
+public interface DifferentialAlgebra {
+
+    /** Get the number of free parameters.
+     * @return number of free parameters
+     */
+    int getFreeParameters();
+
+    /** Get the maximum derivation order.
+     * @return maximum derivation order
+     */
+    int getOrder();
+
+}

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/FieldDerivative.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/FieldDerivative.java
@@ -23,20 +23,11 @@ import org.hipparchus.util.FastMath;
 /** Interface representing both the value and the differentials of a function.
  * @param <S> the type of the field elements
  * @param <T> the type of the function derivative
+ * @see Derivative
  * @since 1.7
  */
 public interface FieldDerivative<S extends CalculusFieldElement<S>, T extends FieldDerivative<S, T>>
-        extends CalculusFieldElement<T> {
-
-    /** Get the number of free parameters.
-     * @return number of free parameters
-     */
-    int getFreeParameters();
-
-    /** Get the derivation order.
-     * @return derivation order
-     */
-    int getOrder();
+        extends CalculusFieldElement<T>, DifferentialAlgebra {
 
     /** Get the value part of the function.
      * @return value part of the value of the function
@@ -65,8 +56,8 @@ public interface FieldDerivative<S extends CalculusFieldElement<S>, T extends Fi
     /** Create an instance corresponding to a constant Field value.
      * <p>
      * This default implementation is there so that no API gets broken
-     * by the next release, which is not a major one. Inheritors should
-     * probably overwrite it.
+     * by the next release, which is not a major one. Custom inheritors
+     * should probably overwrite it.
      * </p>
      * @param value constant value
      * @return instance corresponding to a constant Field value
@@ -74,6 +65,39 @@ public interface FieldDerivative<S extends CalculusFieldElement<S>, T extends Fi
      */
     default T newInstance(S value) {
         return newInstance(value.getReal());
+    }
+
+    /** Create a new object with new value (zeroth-order derivative, as passed as input)
+     * and same derivatives of order one and above.
+     * <p>
+     * This default implementation is there so that no API gets broken
+     * by the next release, which is not a major one. Custom inheritors
+     * should probably overwrite it.
+     * </p>
+     * @param value zeroth-order derivative of new represented function
+     * @return new object with changed value
+     * @since 3.1
+     */
+    default T withValue(S value) {
+        return add(newInstance(value.subtract(getValue())));
+    }
+
+    /** '+' operator.
+     * @param a right hand side parameter of the operator
+     * @return this+a
+     * @since 3.1
+     */
+    default T add(S a) {
+        return withValue(getValue().add(a));
+    }
+
+    /** '-' operator.
+     * @param a right hand side parameter of the operator
+     * @return this-a
+     * @since 3.1
+     */
+    default T subtract(S a) {
+        return withValue(getValue().subtract(a));
     }
 
     /** {@inheritDoc} */
@@ -139,7 +163,7 @@ public interface FieldDerivative<S extends CalculusFieldElement<S>, T extends Fi
     /** {@inheritDoc} */
     @Override
     default int getExponent() {
-        return FastMath.getExponent(getValue().getReal());
+        return getValue().getExponent();
     }
 
 }

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/FieldDerivative1.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/FieldDerivative1.java
@@ -1,0 +1,187 @@
+package org.hipparchus.analysis.differentiation;
+
+import org.hipparchus.CalculusFieldElement;
+import org.hipparchus.util.FastMath;
+import org.hipparchus.util.FieldSinCos;
+import org.hipparchus.util.FieldSinhCosh;
+
+/** Interface representing a Field object holding partial derivatives up to first order.
+ * @see FieldDerivative
+ * @see FieldUnivariateDerivative1
+ * @see FieldGradient
+ * @see Derivative1
+ * @since 3.1
+ */
+public interface FieldDerivative1<S extends CalculusFieldElement<S>, T extends FieldDerivative<S, T>>
+        extends FieldDerivative<S, T> {
+
+    /** {@inheritDoc} */
+    @Override
+    default int getOrder() {
+        return 1;
+    }
+
+    /** Compute composition of the instance by a univariate function differentiable at order 1.
+     * @param f0 value of function
+     * @param f1 first-order derivative
+     * @return f(this)
+     */
+    T compose(S f0, S f1);
+
+    /** {@inheritDoc} */
+    @Override
+    default T square() {
+        final S f0 = getValue();
+        return compose(f0.square(), f0.multiply(2));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T reciprocal() {
+        final S inv1 = getValue().reciprocal();
+        final S inv2 = inv1.square().negate();
+        return compose(inv1, inv2);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T exp() {
+        final S exp = getValue().exp();
+        return compose(exp, exp);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T sqrt() {
+        final S s = getValue().sqrt();
+        return compose(s, s.add(s).reciprocal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T cbrt() {
+        final S c = getValue().cbrt();
+        return compose(c, c.square().multiply(3).reciprocal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T expm1() {
+        final S exp   = FastMath.exp(getValue());
+        final S expM1 = FastMath.expm1(getValue());
+        return compose(expM1, exp);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T log() {
+        return compose(getValue().log(), getValue().reciprocal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T log1p() {
+        return compose(getValue().log1p(), getValue().add(1).reciprocal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T log10() {
+        return compose(getValue().log10(), getValue().multiply(FastMath.log(10.0)).reciprocal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T cos() {
+        final FieldSinCos<S> sinCos = getValue().sinCos();
+        return compose(sinCos.cos(), sinCos.sin().negate());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T sin() {
+        final FieldSinCos<S> sinCos = getValue().sinCos();
+        return compose(sinCos.sin(), sinCos.cos());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default FieldSinCos<T> sinCos() {
+        final FieldSinCos<S> sinCos = getValue().sinCos();
+        return new FieldSinCos<>(compose(sinCos.sin(), sinCos.cos()),
+                compose(sinCos.cos(), sinCos.sin().negate()));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T tan() {
+        final S tan = getValue().tan();
+        return compose(tan, tan.multiply(tan).add(1));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T acos() {
+        return compose(getValue().acos(), getValue().square().negate().add(1).sqrt().reciprocal().negate());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T asin() {
+        return compose(getValue().asin(), getValue().square().negate().add(1).sqrt().reciprocal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T atan() {
+        return compose(getValue().atan(), getValue().square().add(1).reciprocal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T cosh() {
+        final FieldSinhCosh<S> sinhCosh = getValue().sinhCosh();
+        return compose(sinhCosh.cosh(), sinhCosh.sinh());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T sinh() {
+        final FieldSinhCosh<S> sinhCosh = getValue().sinhCosh();
+        return compose(sinhCosh.sinh(), sinhCosh.cosh());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default FieldSinhCosh<T> sinhCosh() {
+        final FieldSinhCosh<S> sinhCosh = getValue().sinhCosh();
+        return new FieldSinhCosh<>(compose(sinhCosh.sinh(), sinhCosh.cosh()),
+                compose(sinhCosh.cosh(), sinhCosh.sinh()));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T tanh() {
+        final S tanh = getValue().tanh();
+        return compose(tanh, tanh.multiply(tanh).negate().add(1));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T acosh() {
+        return compose(getValue().acosh(), getValue().square().subtract(1).sqrt().reciprocal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T asinh() {
+        return compose(getValue().asinh(), getValue().square().add(1).sqrt().reciprocal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default T atanh() {
+        return compose(getValue().atanh(), getValue().square().negate().add(1).reciprocal());
+    }
+
+}

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/FieldDerivativeStructure.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/FieldDerivativeStructure.java
@@ -74,6 +74,15 @@ public class FieldDerivativeStructure<T extends CalculusFieldElement<T>>
         return factory.constant(value);
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public FieldDerivativeStructure<T> withValue(final T value) {
+        final FieldDerivativeStructure<T> ds = factory.build();
+        System.arraycopy(data, 1, ds.data, 1, data.length - 1);
+        ds.data[0] = value;
+        return ds;
+    }
+
     /** Get the factory that built the instance.
      * @return factory that built the instance
      */
@@ -147,17 +156,6 @@ public class FieldDerivativeStructure<T extends CalculusFieldElement<T>>
         return data.clone();
     }
 
-    /** '+' operator.
-     * @param a right hand side parameter of the operator
-     * @return this+a
-     */
-    public FieldDerivativeStructure<T> add(T a) {
-        final FieldDerivativeStructure<T> ds = factory.build();
-        System.arraycopy(data, 0, ds.data, 0, data.length);
-        ds.data[0] = ds.data[0].add(a);
-        return ds;
-    }
-
     /** {@inheritDoc}
      */
     @Override
@@ -178,17 +176,6 @@ public class FieldDerivativeStructure<T extends CalculusFieldElement<T>>
         factory.checkCompatibility(a.factory);
         final FieldDerivativeStructure<T> ds = factory.build();
         factory.getCompiler().add(data, 0, a.data, 0, ds.data, 0);
-        return ds;
-    }
-
-    /** '-' operator.
-     * @param a right hand side parameter of the operator
-     * @return this-a
-     */
-    public FieldDerivativeStructure<T> subtract(final T a) {
-        final FieldDerivativeStructure<T> ds = factory.build();
-        System.arraycopy(data, 0, ds.data, 0, data.length);
-        ds.data[0] = ds.data[0].subtract(a);
         return ds;
     }
 
@@ -349,34 +336,6 @@ public class FieldDerivativeStructure<T extends CalculusFieldElement<T>>
         }
     }
 
-    /** {@inheritDoc}
-     */
-    @Override
-    public FieldDerivativeStructure<T> ceil() {
-        return factory.constant(data[0].ceil());
-    }
-
-    /** {@inheritDoc}
-     */
-    @Override
-    public FieldDerivativeStructure<T> floor() {
-        return factory.constant(data[0].floor());
-    }
-
-    /** {@inheritDoc}
-     */
-    @Override
-    public FieldDerivativeStructure<T> rint() {
-        return factory.constant(data[0].rint());
-    }
-
-    /** {@inheritDoc}
-     */
-    @Override
-    public FieldDerivativeStructure<T> sign() {
-        return factory.constant(data[0].sign());
-    }
-
     /**
      * Returns the instance with the sign of the argument.
      * A NaN {@code sign} argument is treated as positive.
@@ -417,19 +376,6 @@ public class FieldDerivativeStructure<T extends CalculusFieldElement<T>>
         return negate(); // flip sign
     }
 
-    /**
-     * Return the exponent of the instance value, removing the bias.
-     * <p>
-     * For double numbers of the form 2<sup>x</sup>, the unbiased
-     * exponent is exactly x.
-     * </p>
-     * @return exponent for instance in IEEE754 representation, without bias
-     */
-    @Override
-    public int getExponent() {
-        return data[0].getExponent();
-    }
-
     /** {@inheritDoc}
      */
     @Override
@@ -438,19 +384,6 @@ public class FieldDerivativeStructure<T extends CalculusFieldElement<T>>
         for (int i = 0; i < ds.data.length; ++i) {
             ds.data[i] = data[i].scalb(n);
         }
-        return ds;
-    }
-
-    /** {@inheritDoc}
-     * <p>
-     * The {@code ulp} function is a step function, hence all its derivatives are 0.
-     * </p>
-     * @since 2.0
-     */
-    @Override
-    public FieldDerivativeStructure<T> ulp() {
-        final FieldDerivativeStructure<T> ds = factory.build();
-        ds.data[0] = FastMath.ulp(data[0]);
         return ds;
     }
 

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/FieldGradient.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/FieldGradient.java
@@ -53,7 +53,7 @@ import org.hipparchus.util.MathUtils;
  * @see FieldUnivariateDerivative2
  * @since 1.7
  */
-public class FieldGradient<T extends CalculusFieldElement<T>> implements FieldDerivative<T, FieldGradient<T>> {
+public class FieldGradient<T extends CalculusFieldElement<T>> implements FieldDerivative1<T, FieldGradient<T>> {
 
     /** Value of the function. */
     private final T value;
@@ -143,6 +143,12 @@ public class FieldGradient<T extends CalculusFieldElement<T>> implements FieldDe
         return new FieldGradient<>(c, MathArrays.buildArray(value.getField(), grad.length));
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public FieldGradient<T> withValue(final T value) {
+        return new FieldGradient<>(value, grad);
+    }
+
     /** Get the value part of the function.
      * @return value part of the value of the function
      */
@@ -164,12 +170,6 @@ public class FieldGradient<T extends CalculusFieldElement<T>> implements FieldDe
     @Override
     public int getFreeParameters() {
         return grad.length;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public int getOrder() {
-        return 1;
     }
 
     /** {@inheritDoc} */
@@ -224,14 +224,6 @@ public class FieldGradient<T extends CalculusFieldElement<T>> implements FieldDe
         return getField().getConversionFactory().build(derivatives);
     }
 
-    /** '+' operator.
-     * @param a right hand side parameter of the operator
-     * @return this+a
-     */
-    public FieldGradient<T> add(final T a) {
-        return new FieldGradient<>(value.add(a), grad);
-    }
-
     /** {@inheritDoc} */
     @Override
     public FieldGradient<T> add(final double a) {
@@ -246,14 +238,6 @@ public class FieldGradient<T extends CalculusFieldElement<T>> implements FieldDe
             result.grad[i] = grad[i].add(a.grad[i]);
         }
         return result;
-    }
-
-    /** '-' operator.
-     * @param a right hand side parameter of the operator
-     * @return this-a
-     */
-    public FieldGradient<T> subtract(final T a) {
-        return new FieldGradient<>(value.subtract(a), grad);
     }
 
     /** {@inheritDoc} */
@@ -310,16 +294,6 @@ public class FieldGradient<T extends CalculusFieldElement<T>> implements FieldDe
         final FieldGradient<T> result = newInstance(value.multiply(a.value));
         for (int i = 0; i < grad.length; ++i) {
             result.grad[i] = grad[i].multiply(a.value).add(value.multiply(a.grad[i]));
-        }
-        return result;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> square() {
-        final FieldGradient<T> result = newInstance(value.square());
-        for (int i = 0; i < grad.length; ++i) {
-            result.grad[i] = grad[i].multiply(value).multiply(2);
         }
         return result;
     }
@@ -497,18 +471,6 @@ public class FieldGradient<T extends CalculusFieldElement<T>> implements FieldDe
         }
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> reciprocal() {
-        final T inv1  = value.reciprocal();
-        final T mInv2 = inv1.multiply(inv1).negate();
-        final FieldGradient<T> result = newInstance(inv1);
-        for (int i = 0; i < grad.length; ++i) {
-            result.grad[i] = grad[i].multiply(mInv2);
-        }
-        return result;
-    }
-
     /** Compute composition of the instance by a function.
      * @param g0 value of the function at the current point (i.e. at {@code g(getValue())})
      * @param g1 first derivative of the function at the current point (i.e. at {@code g'(getValue())})
@@ -520,20 +482,6 @@ public class FieldGradient<T extends CalculusFieldElement<T>> implements FieldDe
             result.grad[i] = g1.multiply(grad[i]);
         }
         return result;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> sqrt() {
-        final T s = FastMath.sqrt(value);
-        return compose(s, s.add(s).reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> cbrt() {
-        final T c = FastMath.cbrt(value);
-        return compose(c, c.square().multiply(3).reciprocal());
     }
 
     /** {@inheritDoc} */
@@ -599,53 +547,6 @@ public class FieldGradient<T extends CalculusFieldElement<T>> implements FieldDe
 
     /** {@inheritDoc} */
     @Override
-    public FieldGradient<T> exp() {
-        final T exp = FastMath.exp(value);
-        return compose(exp, exp);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> expm1() {
-        final T exp   = FastMath.exp(value);
-        final T expM1 = FastMath.expm1(value);
-        return compose(expM1, exp);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> log() {
-        return compose(FastMath.log(value), value.reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> log1p() {
-        return compose(FastMath.log1p(value), value.add(1).reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> log10() {
-        return compose(FastMath.log10(value), value.multiply(FastMath.log(10.0)).reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> cos() {
-        final FieldSinCos<T> sinCos = FastMath.sinCos(value);
-        return compose(sinCos.cos(), sinCos.sin().negate());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> sin() {
-        final FieldSinCos<T> sinCos = FastMath.sinCos(value);
-        return compose(sinCos.sin(), sinCos.cos());
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public FieldSinCos<FieldGradient<T>> sinCos() {
         final FieldSinCos<T> sinCos = FastMath.sinCos(value);
         final FieldGradient<T> sin = newInstance(sinCos.sin());
@@ -656,31 +557,6 @@ public class FieldGradient<T extends CalculusFieldElement<T>> implements FieldDe
             cos.grad[i] =  grad[i].multiply(mSin);
         }
         return new FieldSinCos<>(sin, cos);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> tan() {
-        final T tan = FastMath.tan(value);
-        return compose(tan, tan.multiply(tan).add(1));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> acos() {
-        return compose(FastMath.acos(value), value.square().negate().add(1).sqrt().reciprocal().negate());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> asin() {
-        return compose(FastMath.asin(value), value.square().negate().add(1).sqrt().reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> atan() {
-        return compose(FastMath.atan(value), value.square().add(1).reciprocal());
     }
 
     /** {@inheritDoc} */
@@ -698,18 +574,6 @@ public class FieldGradient<T extends CalculusFieldElement<T>> implements FieldDe
 
     /** {@inheritDoc} */
     @Override
-    public FieldGradient<T> cosh() {
-        return compose(FastMath.cosh(value), FastMath.sinh(value));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> sinh() {
-        return compose(FastMath.sinh(value), FastMath.cosh(value));
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public FieldSinhCosh<FieldGradient<T>> sinhCosh() {
         final FieldSinhCosh<T> sinhCosh = FastMath.sinhCosh(value);
         final FieldGradient<T> sinh = newInstance(sinhCosh.sinh());
@@ -719,31 +583,6 @@ public class FieldGradient<T extends CalculusFieldElement<T>> implements FieldDe
             cosh.grad[i] = grad[i].multiply(sinhCosh.sinh());
         }
         return new FieldSinhCosh<>(sinh, cosh);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> tanh() {
-        final T tanh = FastMath.tanh(value);
-        return compose(tanh, tanh.multiply(tanh).negate().add(1));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> acosh() {
-        return compose(FastMath.acosh(value), value.square().subtract(1).sqrt().reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> asinh() {
-        return compose(FastMath.asinh(value), value.square().add(1).sqrt().reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldGradient<T> atanh() {
-        return compose(FastMath.atanh(value), value.square().negate().add(1).reciprocal());
     }
 
     /** {@inheritDoc} */

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/FieldTaylorMap.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/FieldTaylorMap.java
@@ -37,7 +37,7 @@ import org.hipparchus.util.MathUtils;
  * @param <T> the type of the function parameters and value
  * @since 2.2
  */
-public class FieldTaylorMap<T extends CalculusFieldElement<T>> {
+public class FieldTaylorMap<T extends CalculusFieldElement<T>> implements DifferentialAlgebra {
 
     /** Evaluation point. */
     private final T[] point;
@@ -99,11 +99,24 @@ public class FieldTaylorMap<T extends CalculusFieldElement<T>> {
         this.functions = (FieldDerivativeStructure<T>[]) Array.newInstance(FieldDerivativeStructure.class, nbFunctions);
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public int getFreeParameters() {
+        return point.length;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getOrder() {
+        return functions[0].getOrder();
+    }
+
     /** Get the number of parameters of the map.
      * @return number of parameters of the map
      */
+    @Deprecated
     public int getNbParameters() {
-        return point.length;
+        return getFreeParameters();
     }
 
     /** Get the number of functions of the map.
@@ -172,7 +185,7 @@ public class FieldTaylorMap<T extends CalculusFieldElement<T>> {
     public FieldTaylorMap<T> compose(final FieldTaylorMap<T> other) {
 
         // safety check
-        MathUtils.checkDimension(getNbParameters(), other.getNbFunctions());
+        MathUtils.checkDimension(getFreeParameters(), other.getNbFunctions());
 
         @SuppressWarnings("unchecked")
         final FieldDerivativeStructure<T>[] composed = (FieldDerivativeStructure<T>[]) Array.newInstance(FieldDerivativeStructure.class,

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/FieldUnivariateDerivative1.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/FieldUnivariateDerivative1.java
@@ -21,8 +21,6 @@ import org.hipparchus.Field;
 import org.hipparchus.exception.LocalizedCoreFormats;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.util.FastMath;
-import org.hipparchus.util.FieldSinCos;
-import org.hipparchus.util.FieldSinhCosh;
 import org.hipparchus.util.MathArrays;
 import org.hipparchus.util.MathUtils;
 
@@ -53,7 +51,8 @@ import org.hipparchus.util.MathUtils;
  * @since 1.7
  */
 public class FieldUnivariateDerivative1<T extends CalculusFieldElement<T>>
-    extends FieldUnivariateDerivative<T, FieldUnivariateDerivative1<T>> {
+    extends FieldUnivariateDerivative<T, FieldUnivariateDerivative1<T>>
+        implements FieldDerivative1<T, FieldUnivariateDerivative1<T>> {
 
     /** Value of the function. */
     private final T f0;
@@ -96,6 +95,12 @@ public class FieldUnivariateDerivative1<T extends CalculusFieldElement<T>>
         return new FieldUnivariateDerivative1<>(value, zero);
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public FieldUnivariateDerivative1<T> withValue(final T value) {
+        return new FieldUnivariateDerivative1<>(value, f1);
+    }
+
     /** Get the value part of the univariate derivative.
      * @return value part of the univariate derivative
      */
@@ -121,14 +126,6 @@ public class FieldUnivariateDerivative1<T extends CalculusFieldElement<T>>
         }
     }
 
-    /** Get the derivation order.
-     * @return derivation order
-     */
-    @Override
-    public int getOrder() {
-        return 1;
-    }
-
     /** Get the first derivative.
      * @return first derivative
      * @see #getValue()
@@ -152,14 +149,6 @@ public class FieldUnivariateDerivative1<T extends CalculusFieldElement<T>>
         return getField().getConversionFactory().build(f0, f1);
     }
 
-    /** '+' operator.
-     * @param a right hand side parameter of the operator
-     * @return this+a
-     */
-    public FieldUnivariateDerivative1<T> add(final T a) {
-        return new FieldUnivariateDerivative1<>(f0.add(a), f1);
-    }
-
     /** {@inheritDoc} */
     @Override
     public FieldUnivariateDerivative1<T> add(final double a) {
@@ -170,14 +159,6 @@ public class FieldUnivariateDerivative1<T extends CalculusFieldElement<T>>
     @Override
     public FieldUnivariateDerivative1<T> add(final FieldUnivariateDerivative1<T> a) {
         return new FieldUnivariateDerivative1<>(f0.add(a.f0), f1.add(a.f1));
-    }
-
-    /** '-' operator.
-     * @param a right hand side parameter of the operator
-     * @return this-a
-     */
-    public FieldUnivariateDerivative1<T> subtract(final T a) {
-        return new FieldUnivariateDerivative1<>(f0.subtract(a), f1);
     }
 
     /** {@inheritDoc} */
@@ -217,12 +198,6 @@ public class FieldUnivariateDerivative1<T extends CalculusFieldElement<T>>
     public FieldUnivariateDerivative1<T> multiply(final FieldUnivariateDerivative1<T> a) {
         return new FieldUnivariateDerivative1<>(f0.multiply(a.f0),
                                                 a.f0.linearCombination(f1, a.f0, f0, a.f1));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> square() {
-        return multiply(this);
     }
 
     /** '&divide;' operator.
@@ -379,14 +354,6 @@ public class FieldUnivariateDerivative1<T extends CalculusFieldElement<T>>
         }
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> reciprocal() {
-        final T inv1 = f0.reciprocal();
-        final T inv2 = inv1.multiply(inv1);
-        return new FieldUnivariateDerivative1<>(inv1, f1.negate().multiply(inv2));
-    }
-
     /** Compute composition of the instance by a function.
      * @param g0 value of the function at the current point (i.e. at {@code g(getValue())})
      * @param g1 first derivative of the function at the current point (i.e. at {@code g'(getValue())})
@@ -394,20 +361,6 @@ public class FieldUnivariateDerivative1<T extends CalculusFieldElement<T>>
      */
     public FieldUnivariateDerivative1<T> compose(final T g0, final T g1) {
         return new FieldUnivariateDerivative1<>(g0, g1.multiply(f1));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> sqrt() {
-        final T s = FastMath.sqrt(f0);
-        return compose(s, s.add(s).reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> cbrt() {
-        final T c = FastMath.cbrt(f0);
-        return compose(c, c.square().multiply(3).reciprocal());
     }
 
     /** {@inheritDoc} */
@@ -468,135 +421,10 @@ public class FieldUnivariateDerivative1<T extends CalculusFieldElement<T>>
 
     /** {@inheritDoc} */
     @Override
-    public FieldUnivariateDerivative1<T> exp() {
-        final T exp = FastMath.exp(f0);
-        return compose(exp, exp);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> expm1() {
-        final T exp   = FastMath.exp(f0);
-        final T expM1 = FastMath.expm1(f0);
-        return compose(expM1, exp);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> log() {
-        return compose(FastMath.log(f0), f0.reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> log1p() {
-        return compose(FastMath.log1p(f0), f0.add(1).reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> log10() {
-        return compose(FastMath.log10(f0), f0.multiply(FastMath.log(10.0)).reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> cos() {
-        final FieldSinCos<T> sinCos = FastMath.sinCos(f0);
-        return compose(sinCos.cos(), sinCos.sin().negate());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> sin() {
-        final FieldSinCos<T> sinCos = FastMath.sinCos(f0);
-        return compose(sinCos.sin(), sinCos.cos());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldSinCos<FieldUnivariateDerivative1<T>> sinCos() {
-        final FieldSinCos<T> sinCos = FastMath.sinCos(f0);
-        return new FieldSinCos<>(new FieldUnivariateDerivative1<>(sinCos.sin(), f1.multiply(sinCos.cos())),
-                                 new FieldUnivariateDerivative1<>(sinCos.cos(), f1.multiply(sinCos.sin()).negate()));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> tan() {
-        final T tan = FastMath.tan(f0);
-        return compose(tan, tan.multiply(tan).add(1));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> acos() {
-        return compose(FastMath.acos(f0), f0.square().negate().add(1).sqrt().reciprocal().negate());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> asin() {
-        return compose(FastMath.asin(f0), f0.square().negate().add(1).sqrt().reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> atan() {
-        return compose(FastMath.atan(f0), f0.square().add(1).reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public FieldUnivariateDerivative1<T> atan2(final FieldUnivariateDerivative1<T> x) {
         final T inv = f0.square().add(x.f0.multiply(x.f0)).reciprocal();
         return new FieldUnivariateDerivative1<>(FastMath.atan2(f0, x.f0),
                                                 f0.linearCombination(x.f0, f1, x.f1.negate(), f0).multiply(inv));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> cosh() {
-        return compose(FastMath.cosh(f0), FastMath.sinh(f0));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> sinh() {
-        return compose(FastMath.sinh(f0), FastMath.cosh(f0));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldSinhCosh<FieldUnivariateDerivative1<T>> sinhCosh() {
-        final FieldSinhCosh<T> sinhCosh = FastMath.sinhCosh(f0);
-        return new FieldSinhCosh<>(new FieldUnivariateDerivative1<>(sinhCosh.sinh(), f1.multiply(sinhCosh.cosh())),
-                                   new FieldUnivariateDerivative1<>(sinhCosh.cosh(), f1.multiply(sinhCosh.sinh())));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> tanh() {
-        final T tanh = FastMath.tanh(f0);
-        return compose(tanh, tanh.multiply(tanh).negate().add(1));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> acosh() {
-        return compose(FastMath.acosh(f0), f0.square().subtract(1).sqrt().reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> asinh() {
-        return compose(FastMath.asinh(f0), f0.square().add(1).sqrt().reciprocal());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldUnivariateDerivative1<T> atanh() {
-        return compose(FastMath.atanh(f0), f0.square().negate().add(1).reciprocal());
     }
 
     /** {@inheritDoc} */

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/FieldUnivariateDerivative2.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/FieldUnivariateDerivative2.java
@@ -102,6 +102,12 @@ public class FieldUnivariateDerivative2<T extends CalculusFieldElement<T>>
         return new FieldUnivariateDerivative2<>(value, zero, zero);
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public FieldUnivariateDerivative2<T> withValue(final T value) {
+        return new FieldUnivariateDerivative2<>(value, f1, f2);
+    }
+
     /** Get the value part of the univariate derivative.
      * @return value part of the univariate derivative
      */
@@ -169,14 +175,6 @@ public class FieldUnivariateDerivative2<T extends CalculusFieldElement<T>>
         return getField().getConversionFactory().build(f0, f1, f2);
     }
 
-    /** '+' operator.
-     * @param a right hand side parameter of the operator
-     * @return this+a
-     */
-    public FieldUnivariateDerivative2<T> add(final T a) {
-        return new FieldUnivariateDerivative2<>(f0.add(a), f1, f2);
-    }
-
     /** {@inheritDoc} */
     @Override
     public FieldUnivariateDerivative2<T> add(final double a) {
@@ -187,14 +185,6 @@ public class FieldUnivariateDerivative2<T extends CalculusFieldElement<T>>
     @Override
     public FieldUnivariateDerivative2<T> add(final FieldUnivariateDerivative2<T> a) {
         return new FieldUnivariateDerivative2<>(f0.add(a.f0), f1.add(a.f1), f2.add(a.f2));
-    }
-
-    /** '-' operator.
-     * @param a right hand side parameter of the operator
-     * @return this-a
-     */
-    public FieldUnivariateDerivative2<T> subtract(final T a) {
-        return new FieldUnivariateDerivative2<>(f0.subtract(a), f1, f2);
     }
 
     /** {@inheritDoc} */

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/TaylorMap.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/TaylorMap.java
@@ -31,7 +31,7 @@ import org.hipparchus.util.MathUtils;
  * </p>
  * @since 2.2
  */
-public class TaylorMap {
+public class TaylorMap implements DifferentialAlgebra {
 
     /** Evaluation point. */
     private final double[] point;
@@ -90,11 +90,24 @@ public class TaylorMap {
         this.functions = new DerivativeStructure[nbFunctions];
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public int getFreeParameters() {
+        return point.length;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getOrder() {
+        return functions[0].getOrder();
+    }
+
     /** Get the number of parameters of the map.
      * @return number of parameters of the map
      */
+    @Deprecated
     public int getNbParameters() {
-        return point.length;
+        return getFreeParameters();
     }
 
     /** Get the number of functions of the map.
@@ -150,7 +163,7 @@ public class TaylorMap {
     public TaylorMap compose(final TaylorMap other) {
 
         // safety check
-        MathUtils.checkDimension(getNbParameters(), other.getNbFunctions());
+        MathUtils.checkDimension(getFreeParameters(), other.getNbFunctions());
 
         final DerivativeStructure[] composed = new DerivativeStructure[functions.length];
         for (int i = 0; i < functions.length; ++i) {

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/UnivariateDerivative1.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/UnivariateDerivative1.java
@@ -19,12 +19,8 @@ package org.hipparchus.analysis.differentiation;
 import org.hipparchus.exception.LocalizedCoreFormats;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.util.FastMath;
-import org.hipparchus.util.FieldSinCos;
-import org.hipparchus.util.FieldSinhCosh;
 import org.hipparchus.util.MathArrays;
 import org.hipparchus.util.MathUtils;
-import org.hipparchus.util.SinCos;
-import org.hipparchus.util.SinhCosh;
 
 /** Class representing both the value and the differentials of a function.
  * <p>This class is a stripped-down version of {@link DerivativeStructure}
@@ -51,7 +47,8 @@ import org.hipparchus.util.SinhCosh;
  * @see FieldGradient
  * @since 1.7
  */
-public class UnivariateDerivative1 extends UnivariateDerivative<UnivariateDerivative1> {
+public class UnivariateDerivative1 extends UnivariateDerivative<UnivariateDerivative1>
+        implements Derivative1<UnivariateDerivative1> {
 
     /** The constant value of π as a {@code UnivariateDerivative1}.
      * @since 2.0
@@ -96,6 +93,12 @@ public class UnivariateDerivative1 extends UnivariateDerivative<UnivariateDeriva
 
     /** {@inheritDoc} */
     @Override
+    public UnivariateDerivative1 withValue(final double value) {
+        return new UnivariateDerivative1(value, f1);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public double getValue() {
         return f0;
     }
@@ -111,12 +114,6 @@ public class UnivariateDerivative1 extends UnivariateDerivative<UnivariateDeriva
             default :
                 throw new MathIllegalArgumentException(LocalizedCoreFormats.DERIVATION_ORDER_NOT_ALLOWED, n);
         }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public int getOrder() {
-        return 1;
     }
 
     /** Get the first derivative.
@@ -135,20 +132,8 @@ public class UnivariateDerivative1 extends UnivariateDerivative<UnivariateDeriva
 
     /** {@inheritDoc} */
     @Override
-    public UnivariateDerivative1 add(final double a) {
-        return new UnivariateDerivative1(f0 + a, f1);
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public UnivariateDerivative1 add(final UnivariateDerivative1 a) {
         return new UnivariateDerivative1(f0 + a.f0, f1 + a.f1);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 subtract(final double a) {
-        return new UnivariateDerivative1(f0 - a, f1);
     }
 
     /** {@inheritDoc} */
@@ -178,12 +163,6 @@ public class UnivariateDerivative1 extends UnivariateDerivative<UnivariateDeriva
 
     /** {@inheritDoc} */
     @Override
-    public UnivariateDerivative1 square() {
-        return new UnivariateDerivative1(f0 * f0, 2 * f0 * f1);
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public UnivariateDerivative1 divide(final double a) {
         final double inv1 = 1.0 / a;
         return new UnivariateDerivative1(f0 * inv1, f1 * inv1);
@@ -196,12 +175,6 @@ public class UnivariateDerivative1 extends UnivariateDerivative<UnivariateDeriva
         final double inv2 = inv1 * inv1;
         return new UnivariateDerivative1(f0 * inv1,
                                          MathArrays.linearCombination(f1, a.f0, -f0, a.f1) * inv2);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 remainder(final double a) {
-        return new UnivariateDerivative1(FastMath.IEEEremainder(f0, a), f1);
     }
 
     /** {@inheritDoc} */
@@ -302,44 +275,15 @@ public class UnivariateDerivative1 extends UnivariateDerivative<UnivariateDeriva
 
     /** {@inheritDoc} */
     @Override
-    public UnivariateDerivative1 reciprocal() {
-        final double inv1 = 1.0 / f0;
-        final double inv2 = inv1 * inv1;
-        return new UnivariateDerivative1(inv1, -f1 * inv2);
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public UnivariateDerivative1 compose(final double... f) {
         MathUtils.checkDimension(f.length, getOrder() + 1);
-        return new UnivariateDerivative1(f[0], f[1] * f1);
+        return compose(f[0], f[1]);
     }
 
     /** {@inheritDoc} */
     @Override
-    public UnivariateDerivative1 sqrt() {
-        final double s = FastMath.sqrt(f0);
-        return compose(s, 1 / (2 * s));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 cbrt() {
-        final double c = FastMath.cbrt(f0);
-        return compose(c, 1 / (3 * c * c));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 rootN(final int n) {
-        if (n == 2) {
-            return sqrt();
-        } else if (n == 3) {
-            return cbrt();
-        } else {
-            final double r = FastMath.pow(f0, 1.0 / n);
-            return compose(r, 1 / (n * FastMath.pow(r, n - 1)));
-        }
+    public UnivariateDerivative1 compose(final double f0, final double f1) {
+        return new UnivariateDerivative1(f0, this.f1 * f1);
     }
 
     /** {@inheritDoc} */
@@ -386,135 +330,10 @@ public class UnivariateDerivative1 extends UnivariateDerivative<UnivariateDeriva
 
     /** {@inheritDoc} */
     @Override
-    public UnivariateDerivative1 exp() {
-        final double exp = FastMath.exp(f0);
-        return compose(exp, exp);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 expm1() {
-        final double exp   = FastMath.exp(f0);
-        final double expM1 = FastMath.expm1(f0);
-        return compose(expM1, exp);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 log() {
-        return compose(FastMath.log(f0), 1 / f0);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 log1p() {
-        return compose(FastMath.log1p(f0), 1 / (1 + f0));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 log10() {
-        return compose(FastMath.log10(f0), 1 / (f0 * FastMath.log(10.0)));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 cos() {
-        final SinCos sinCos = FastMath.sinCos(f0);
-        return compose(sinCos.cos(), -sinCos.sin());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 sin() {
-        final SinCos sinCos = FastMath.sinCos(f0);
-        return compose(sinCos.sin(), sinCos.cos());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldSinCos<UnivariateDerivative1> sinCos() {
-        final SinCos sinCos = FastMath.sinCos(f0);
-        return new FieldSinCos<>(new UnivariateDerivative1(sinCos.sin(),  f1 * sinCos.cos()),
-                                 new UnivariateDerivative1(sinCos.cos(), -f1 * sinCos.sin()));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 tan() {
-        final double tan = FastMath.tan(f0);
-        return compose(tan, 1 + tan * tan);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 acos() {
-        return compose(FastMath.acos(f0), -1 / FastMath.sqrt(1 - f0 * f0));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 asin() {
-        return compose(FastMath.asin(f0), 1 / FastMath.sqrt(1 - f0 * f0));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 atan() {
-        return compose(FastMath.atan(f0), 1 / (1 + f0 * f0));
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public UnivariateDerivative1 atan2(final UnivariateDerivative1 x) {
         final double inv = 1.0 / (f0 * f0 + x.f0 * x.f0);
         return new UnivariateDerivative1(FastMath.atan2(f0, x.f0),
                                          MathArrays.linearCombination(x.f0, f1, -x.f1, f0) * inv);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 cosh() {
-        return compose(FastMath.cosh(f0), FastMath.sinh(f0));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 sinh() {
-        return compose(FastMath.sinh(f0), FastMath.cosh(f0));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public FieldSinhCosh<UnivariateDerivative1> sinhCosh() {
-        final SinhCosh sinhCosh = FastMath.sinhCosh(f0);
-        return new FieldSinhCosh<>(new UnivariateDerivative1(sinhCosh.sinh(), f1 * sinhCosh.cosh()),
-                                   new UnivariateDerivative1(sinhCosh.cosh(), f1 * sinhCosh.sinh()));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 tanh() {
-        final double tanh = FastMath.tanh(f0);
-        return compose(tanh, 1 - tanh * tanh);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 acosh() {
-        return compose(FastMath.acosh(f0), 1 / FastMath.sqrt(f0 * f0 - 1));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 asinh() {
-        return compose(FastMath.asinh(f0), 1 / FastMath.sqrt(f0 * f0 + 1));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative1 atanh() {
-        return compose(FastMath.atanh(f0), 1 / (1 - f0 * f0));
     }
 
     /** {@inheritDoc} */

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/UnivariateDerivative2.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/differentiation/UnivariateDerivative2.java
@@ -100,6 +100,11 @@ public class UnivariateDerivative2 extends UnivariateDerivative<UnivariateDeriva
         return new UnivariateDerivative2(value, 0.0, 0.0);
     }
 
+    @Override
+    public UnivariateDerivative2 withValue(final double value) {
+        return new UnivariateDerivative2(value, f1, f2);
+    }
+
     /** {@inheritDoc} */
     @Override
     public double getValue() {
@@ -153,20 +158,8 @@ public class UnivariateDerivative2 extends UnivariateDerivative<UnivariateDeriva
 
     /** {@inheritDoc} */
     @Override
-    public UnivariateDerivative2 add(final double a) {
-        return new UnivariateDerivative2(f0 + a, f1, f2);
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public UnivariateDerivative2 add(final UnivariateDerivative2 a) {
         return new UnivariateDerivative2(f0 + a.f0, f1 + a.f1, f2 + a.f2);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative2 subtract(final double a) {
-        return new UnivariateDerivative2(f0 - a, f1, f2);
     }
 
     /** {@inheritDoc} */
@@ -220,12 +213,6 @@ public class UnivariateDerivative2 extends UnivariateDerivative<UnivariateDeriva
                                                                       -2 * f1, a.f0 * a.f1,
                                                                        2 * f0, a.f1 * a.f1,
                                                                        -f0, a.f0 * a.f2) * inv3);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public UnivariateDerivative2 remainder(final double a) {
-        return new UnivariateDerivative2(FastMath.IEEEremainder(f0, a), f1, f2);
     }
 
     /** {@inheritDoc} */

--- a/hipparchus-core/src/main/java/org/hipparchus/fraction/BigFraction.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/fraction/BigFraction.java
@@ -966,11 +966,6 @@ public class BigFraction
                                denominator.multiply(fraction.denominator));
     }
 
-    @Override
-    public BigFraction square() throws NullArgumentException {
-        return multiply(this);
-    }
-
     /**
      * <p>
      * Return the additive inverse of this fraction, returning the result in

--- a/hipparchus-core/src/main/java/org/hipparchus/fraction/Fraction.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/fraction/Fraction.java
@@ -615,12 +615,6 @@ public class Fraction
         return multiply(new Fraction(i));
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public Fraction square() throws NullArgumentException {
-        return multiply(this);
-    }
-
     /**
      * Divide the value of this fraction by another.
      *

--- a/hipparchus-core/src/main/java/org/hipparchus/util/BigReal.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/util/BigReal.java
@@ -295,12 +295,6 @@ public class BigReal implements FieldElement<BigReal>, Comparable<BigReal>, Seri
 
     /** {@inheritDoc} */
     @Override
-    public BigReal square() throws NullArgumentException {
-        return multiply(this);
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public int compareTo(BigReal a) {
         return d.compareTo(a.d);
     }

--- a/hipparchus-core/src/test/java/org/hipparchus/CalculusFieldElementTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/CalculusFieldElementTest.java
@@ -267,6 +267,66 @@ public class CalculusFieldElementTest {
     }
 
     @Test
+    public void testSign() {
+        // GIVEN
+        final double value = 3.6;
+        final TestCalculusFieldElement testElement = new TestCalculusFieldElement(value);
+        // WHEN
+        final TestCalculusFieldElement actualOperation = testElement.sign();
+        // THEN
+        final TestCalculusFieldElement expectedOperation = new TestCalculusFieldElement(FastMath.signum(value));
+        Assert.assertEquals(expectedOperation, actualOperation);
+    }
+
+    @Test
+    public void testUlp() {
+        // GIVEN
+        final double value = 3.6;
+        final TestCalculusFieldElement testElement = new TestCalculusFieldElement(value);
+        // WHEN
+        final TestCalculusFieldElement actualOperation = testElement.ulp();
+        // THEN
+        final TestCalculusFieldElement expectedOperation = new TestCalculusFieldElement(FastMath.ulp(value));
+        Assert.assertEquals(expectedOperation, actualOperation);
+    }
+
+    @Test
+    public void testFloor() {
+        // GIVEN
+        final double value = 3.6;
+        final TestCalculusFieldElement testElement = new TestCalculusFieldElement(value);
+        // WHEN
+        final TestCalculusFieldElement actualOperation = testElement.floor();
+        // THEN
+        final TestCalculusFieldElement expectedOperation = new TestCalculusFieldElement(FastMath.floor(value));
+        Assert.assertEquals(expectedOperation, actualOperation);
+    }
+
+    @Test
+    public void testCeil() {
+        // GIVEN
+        final double value = 3.6;
+        final TestCalculusFieldElement testElement = new TestCalculusFieldElement(value);
+        // WHEN
+        final TestCalculusFieldElement actualOperation = testElement.ceil();
+        // THEN
+        final TestCalculusFieldElement expectedOperation = new TestCalculusFieldElement(FastMath.ceil(value));
+        Assert.assertEquals(expectedOperation, actualOperation);
+    }
+
+    @Test
+    public void testRint() {
+        // GIVEN
+        final double value = 3.6;
+        final TestCalculusFieldElement testElement = new TestCalculusFieldElement(value);
+        // WHEN
+        final TestCalculusFieldElement actualOperation = testElement.rint();
+        // THEN
+        final TestCalculusFieldElement expectedOperation = new TestCalculusFieldElement(FastMath.rint(value));
+        Assert.assertEquals(expectedOperation, actualOperation);
+    }
+
+    @Test
     public void testToDegrees() {
         // GIVEN
         final double value = 3.;
@@ -385,7 +445,7 @@ public class CalculusFieldElementTest {
 
         @Override
         public TestCalculusFieldElement ulp() {
-            return null;
+            return new TestCalculusFieldElement(FastMath.ulp(value));
         }
 
         @Override
@@ -501,17 +561,17 @@ public class CalculusFieldElementTest {
 
         @Override
         public TestCalculusFieldElement ceil() {
-            return null;
+            return new TestCalculusFieldElement(FastMath.ceil(value));
         }
 
         @Override
         public TestCalculusFieldElement floor() {
-            return null;
+            return new TestCalculusFieldElement(FastMath.floor(value));
         }
 
         @Override
         public TestCalculusFieldElement rint() {
-            return null;
+            return new TestCalculusFieldElement(FastMath.rint(value));
         }
 
         @Override
@@ -526,7 +586,7 @@ public class CalculusFieldElementTest {
 
         @Override
         public TestCalculusFieldElement sign() {
-            return null;
+            return new TestCalculusFieldElement(FastMath.signum(value));
         }
 
         @Override

--- a/hipparchus-core/src/test/java/org/hipparchus/analysis/differentiation/DerivativeTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/analysis/differentiation/DerivativeTest.java
@@ -40,6 +40,32 @@ public class DerivativeTest {
     }
 
     @Test
+    public void testAddDouble() {
+        // GIVEN
+        final double value = 0.5;
+        final TestDerivative testDerivative = new TestDerivative(value);
+        final double scalar = 2.;
+        // WHEN
+        final TestDerivative actualOperation = testDerivative.add(scalar);
+        // THEN
+        final TestDerivative expectedOperation = new TestDerivative(value + scalar);
+        Assert.assertEquals(expectedOperation.getValue(), actualOperation.getValue(), TOLERANCE);
+    }
+
+    @Test
+    public void testSubtractDouble() {
+        // GIVEN
+        final double value = 0.5;
+        final TestDerivative testDerivative = new TestDerivative(value);
+        final double scalar = 2.;
+        // WHEN
+        final TestDerivative actualOperation = testDerivative.subtract(scalar);
+        // THEN
+        final TestDerivative expectedOperation = new TestDerivative(value - scalar);
+        Assert.assertEquals(expectedOperation.getValue(), actualOperation.getValue(), TOLERANCE);
+    }
+
+    @Test
     public void testLog10() {
         // GIVEN
         final double value = 0.5;
@@ -98,54 +124,6 @@ public class DerivativeTest {
         final TestDerivative actualOperation = testDerivative.acos();
         // THEN
         final TestDerivative expectedOperation = new TestDerivative(FastMath.acos(value));
-        Assert.assertEquals(expectedOperation.getValue(), actualOperation.getValue(), TOLERANCE);
-    }
-
-    @Test
-    public void testFloor() {
-        // GIVEN
-        final double value = 0.5;
-        final TestDerivative testDerivative = new TestDerivative(value);
-        // WHEN
-        final TestDerivative actualOperation = testDerivative.floor();
-        // THEN
-        final TestDerivative expectedOperation = new TestDerivative(FastMath.floor(value));
-        Assert.assertEquals(expectedOperation, actualOperation);
-    }
-
-    @Test
-    public void testCeil() {
-        // GIVEN
-        final double value = 0.5;
-        final TestDerivative testDerivative = new TestDerivative(value);
-        // WHEN
-        final TestDerivative actualOperation = testDerivative.ceil();
-        // THEN
-        final TestDerivative expectedOperation = new TestDerivative(FastMath.ceil(value));
-        Assert.assertEquals(expectedOperation.getValue(), actualOperation.getValue(), TOLERANCE);
-    }
-
-    @Test
-    public void testRint() {
-        // GIVEN
-        final double value = 0.5;
-        final TestDerivative testDerivative = new TestDerivative(value);
-        // WHEN
-        final TestDerivative actualOperation = testDerivative.rint();
-        // THEN
-        final TestDerivative expectedOperation = new TestDerivative(FastMath.rint(value));
-        Assert.assertEquals(expectedOperation, actualOperation);
-    }
-
-    @Test
-    public void testSign() {
-        // GIVEN
-        final double value = 0.5;
-        final TestDerivative testDerivative = new TestDerivative(value);
-        // WHEN
-        final TestDerivative actualOperation = testDerivative.sign();
-        // THEN
-        final TestDerivative expectedOperation = new TestDerivative(FastMath.signum(value));
         Assert.assertEquals(expectedOperation.getValue(), actualOperation.getValue(), TOLERANCE);
     }
 
@@ -251,11 +229,6 @@ public class DerivativeTest {
         @Override
         public TestDerivative linearCombination(TestDerivative a1, TestDerivative b1, TestDerivative a2, TestDerivative b2,
                                                 TestDerivative a3, TestDerivative b3, TestDerivative a4, TestDerivative b4) {
-            return null;
-        }
-
-        @Override
-        public TestDerivative remainder(double a) {
             return null;
         }
 

--- a/hipparchus-core/src/test/java/org/hipparchus/analysis/differentiation/FieldTaylorMapTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/analysis/differentiation/FieldTaylorMapTest.java
@@ -199,7 +199,7 @@ public class FieldTaylorMapTest {
             functions[i] = factory.constant(0);
         }
         Assert.assertEquals(nbParameters,
-                            new FieldTaylorMap<>(MathArrays.buildArray(field, nbParameters), functions).getNbParameters());
+                            new FieldTaylorMap<>(MathArrays.buildArray(field, nbParameters), functions).getFreeParameters());
     }
 
     private <T extends CalculusFieldElement<T>> void doTestNbFunctions(final Field<T> field) {
@@ -365,7 +365,7 @@ public class FieldTaylorMapTest {
         f[1] = p1;
         f[2] = p0.add(p1);
         final FieldTaylorMap<T> nonSquare = new FieldTaylorMap<>(p, f);
-        Assert.assertEquals(2, nonSquare.getNbParameters());
+        Assert.assertEquals(2, nonSquare.getFreeParameters());
         Assert.assertEquals(3, nonSquare.getNbFunctions());
         try {
             nonSquare.invert(new FieldQRDecomposer<>(field.getZero().newInstance(1.0e-10)));

--- a/hipparchus-core/src/test/java/org/hipparchus/analysis/differentiation/SparseGradientTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/analysis/differentiation/SparseGradientTest.java
@@ -49,7 +49,7 @@ public class SparseGradientTest extends CalculusFieldElementAbstractTest<SparseG
         double c = 1.0;
         SparseGradient grad = SparseGradient.createConstant(c);
         Assert.assertEquals(c, grad.getValue(), 1.0e-15); // returns the value
-        Assert.assertEquals(0, grad.numVars(), 1.0e-15); // has no variables
+        Assert.assertEquals(0, grad.getFreeParameters(), 1.0e-15); // has no variables
     }
 
     @Test
@@ -58,7 +58,7 @@ public class SparseGradientTest extends CalculusFieldElementAbstractTest<SparseG
         int id = 0;
         SparseGradient grad = SparseGradient.createVariable(id, v);
         Assert.assertEquals(v, grad.getValue(), 1.0e-15); // returns the value
-        Assert.assertEquals(1, grad.numVars(), 1.0e-15); // has one variable
+        Assert.assertEquals(1, grad.getFreeParameters(), 1.0e-15); // has one variable
         Assert.assertEquals(1.0, grad.getDerivative(id), 1.0e-15); // derivative wr.t itself is 1
     }
 
@@ -73,7 +73,7 @@ public class SparseGradientTest extends CalculusFieldElementAbstractTest<SparseG
         final SparseGradient sum = var1.add(var2);
 
         Assert.assertEquals(v1 + v2, sum.getValue(), 1.0e-15); // returns the value
-        Assert.assertEquals(2, sum.numVars());
+        Assert.assertEquals(2, sum.getFreeParameters());
         Assert.assertEquals(1.0, sum.getDerivative(id1), 1.0e-15);
         Assert.assertEquals(1.0, sum.getDerivative(id2), 1.0e-15);
     }
@@ -89,7 +89,7 @@ public class SparseGradientTest extends CalculusFieldElementAbstractTest<SparseG
         final SparseGradient sum = var1.subtract(var2);
 
         Assert.assertEquals(v1 - v2, sum.getValue(), 1.0e-15); // returns the value
-        Assert.assertEquals(2, sum.numVars());
+        Assert.assertEquals(2, sum.getFreeParameters());
         Assert.assertEquals(1.0, sum.getDerivative(id1), 1.0e-15);
         Assert.assertEquals(-1.0, sum.getDerivative(id2), 1.0e-15);
     }
@@ -104,7 +104,7 @@ public class SparseGradientTest extends CalculusFieldElementAbstractTest<SparseG
         final SparseGradient var2 = SparseGradient.createVariable(id2, v2);
         final SparseGradient out = var1.divide(var2);
         Assert.assertEquals(v1 / v2, out.getValue(), 1.0e-15); // returns the value
-        Assert.assertEquals(2, out.numVars());
+        Assert.assertEquals(2, out.getFreeParameters());
         Assert.assertEquals(1 / v2, out.getDerivative(id1), 1.0e-15);
         Assert.assertEquals(-1 / (v2 * v2), out.getDerivative(id2), 1.0e-15);
     }
@@ -121,7 +121,7 @@ public class SparseGradientTest extends CalculusFieldElementAbstractTest<SparseG
         final SparseGradient unit2 = SparseGradient.createVariable(id2, v2).multiply(var1);
         final SparseGradient sum = unit1.add(unit2);
         Assert.assertEquals(v1 * c1 + v2 * v1, sum.getValue(), 1.0e-15); // returns the value
-        Assert.assertEquals(2, sum.numVars());
+        Assert.assertEquals(2, sum.getFreeParameters());
         Assert.assertEquals(c1 + v2, sum.getDerivative(id1), 1.0e-15);
         Assert.assertEquals(v1, sum.getDerivative(id2), 1.0e-15);
     }
@@ -139,7 +139,7 @@ public class SparseGradientTest extends CalculusFieldElementAbstractTest<SparseG
         mult.multiplyInPlace(var1);
         sum.addInPlace(mult);
         Assert.assertEquals(v1 * c1 + v2 * v1, sum.getValue(), 1.0e-15); // returns the value
-        Assert.assertEquals(2, sum.numVars());
+        Assert.assertEquals(2, sum.getFreeParameters());
         Assert.assertEquals(c1 + v2, sum.getDerivative(id1), 1.0e-15);
         Assert.assertEquals(v1, sum.getDerivative(id2), 1.0e-15);
     }
@@ -1127,7 +1127,7 @@ public class SparseGradientTest extends CalculusFieldElementAbstractTest<SparseG
     @Test
     public void testZero() {
         SparseGradient zero = SparseGradient.createVariable(0, 17.0).getField().getZero();
-        Assert.assertEquals(0, zero.numVars());
+        Assert.assertEquals(0, zero.getFreeParameters());
         Assert.assertEquals(0.0, zero.getValue(), 1.0e-15);
         Assert.assertEquals(0.0, zero.getDerivative(0), 1.0e-15);
     }
@@ -1135,7 +1135,7 @@ public class SparseGradientTest extends CalculusFieldElementAbstractTest<SparseG
     @Test
     public void testOne() {
         SparseGradient one = SparseGradient.createVariable(0, 17.0).getField().getOne();
-        Assert.assertEquals(0, one.numVars());
+        Assert.assertEquals(0, one.getFreeParameters());
         Assert.assertEquals(1.0, one.getValue(), 1.0e-15);
         Assert.assertEquals(0.0, one.getDerivative(0), 1.0e-15);
     }

--- a/hipparchus-core/src/test/java/org/hipparchus/analysis/differentiation/TaylorMapTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/analysis/differentiation/TaylorMapTest.java
@@ -120,7 +120,7 @@ public class TaylorMapTest {
             functions[i] = factory.constant(0);
         }
         Assert.assertEquals(nbParameters,
-                            new TaylorMap(new double[nbParameters], functions).getNbParameters());
+                            new TaylorMap(new double[nbParameters], functions).getFreeParameters());
     }
 
     @Test
@@ -258,7 +258,7 @@ public class TaylorMapTest {
         final DerivativeStructure p1        = factory.variable(1, -3.0);
         final TaylorMap           nonSquare = new TaylorMap(new double[] { p0.getValue(), p1.getValue() },
                                                             new DerivativeStructure[] { p0, p1, p0.add(p1) });
-        Assert.assertEquals(2, nonSquare.getNbParameters());
+        Assert.assertEquals(2, nonSquare.getFreeParameters());
         Assert.assertEquals(3, nonSquare.getNbFunctions());
         try {
             nonSquare.invert(new QRDecomposer(1.0e-10));

--- a/hipparchus-core/src/test/java/org/hipparchus/analysis/interpolation/FieldHermiteInterpolatorTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/analysis/interpolation/FieldHermiteInterpolatorTest.java
@@ -231,7 +231,7 @@ public class FieldHermiteInterpolatorTest {
                                     new BigFraction[] { new BigFraction(56) });
         for (BigFraction x = new BigFraction(-1); x.doubleValue() <= 1.0; x = x.add(new BigFraction(1, 8))) {
             BigFraction y = interpolator.value(x)[0];
-            BigFraction x2 = x.square();
+            BigFraction x2 = x.multiply(x);
             BigFraction x4 = x2.multiply(x2);
             BigFraction x8 = x4.multiply(x4);
             Assert.assertEquals(x8.add(new BigFraction(1)), y);

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -50,11 +50,14 @@ If the output is not quite correct, check for invisible trailing spaces!
   </properties>
   <body>
     <release version="3.1" date="TBD" description="TBD.">
+      <action dev="serrof" type="update" issue="issues/286">
+        Rework interfaces for Derivative and FieldDerivative.
+      </action>
       <action dev="serrof" type="add" issue="issues/281">
         Add default implementations in CalculusFieldElement and inheritors.
       </action>
       <action dev="serrof" type="add" issue="issues/280">
-        Add square method to FieldElement.
+        Add square method to CalculusFieldElement.
       </action>
     </release>
     <release version="3.0" date="2023-10-08" description="This is a major release.">


### PR DESCRIPTION
Closes #286 

Four main things:
- introduced (Field)Derivative1 to reduce code duplication between univariate and multivariate first order classes
- make `SparseGradient` inherit from `Derivative1`
- introduced a new interface called `DifferentialAlgebra` that defines number of variables and maximum order. It enables unification between `Derivative` and `TaylorMap` as well as their `Field` equivalent
- fixed an API break introduced on #280  when adding square to `FieldElement` (no default). Now only `CalculusFieldElement` has it, with a default implementation.