### PR TITLE
fixes 302: improved performance of Gradient

### DIFF
--- a/hipparchus-core/src/changes/changes.xml
+++ b/hipparchus-core/src/changes/changes.xml
@@ -50,6 +50,9 @@ If the output is not quite correct, check for invisible trailing spaces!
   </properties>
   <body>
     <release version="3.1" date="TBD" description="TBD.">
+      <action dev="serrof" type="update" issue="issues/302">
+        Improved performance of Gradient.
+      </action>
       <action dev="luc" type="fix" due-to="Axel Kramer" issue="issues/294">
         Added GCD and LCM to {Big}Fraction.
       </action>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -50,6 +50,9 @@ If the output is not quite correct, check for invisible trailing spaces!
   </properties>
   <body>
     <release version="3.1" date="TBD" description="TBD.">
+      <action dev="serrof" type="update" issue="issues/302">
+        Improved performance of Gradient.
+      </action>
       <action dev="serrof" type="fix" issue="issues/290">
         Fixes regressions with Field in event detection.
       </action>


### PR DESCRIPTION
Closes #302 

On `add`, with  6 variables, improvement is about 50% faster according to this:

    @Test
    public void perfo() {
        final Gradient gradient = Gradient.variable(6, 0, 0);
        for (int i = 0; i < 1000000000; i++) {
            addItself(gradient);
        }
    }

    private void addItself(final Gradient gradient) {
        gradient.add(gradient);
    }

