### PR TITLE
Update CI/CD pipeline and environment to the new SonarQube requirements

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,21 +7,28 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 8
-      uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
       with:
-        distribution: 'zulu'
-        java-version: 8
+        distribution: 'temurin'
+        java-version: 11
     - name: Build with Maven
       run: mvn -B -U -f pom.xml install checkstyle:checkstyle
     - name: SonarQube scan
       run: |
         if [ $PROJECT_KEY != 'Hipparchus-Math/hipparchus' ] ; then export KEY_OPTION="-Dsonar.projectKey=${PROJECT_KEY/\//:}" ; fi
         if [ $PROJECT_KEY != 'Hipparchus-Math/hipparchus' ] ; then export PROJECT_NAME="$PROJECT_NAME ($PROJECT_KEY)" ; fi
-        mvn -B -f pom.xml sonar:sonar -Dsonar.login=$SONARQUBE_TOKEN -Dsonar.branch.name=${GITHUB_REF##*/} $KEY_OPTION -Dsonar.projectName="$PROJECT_NAME"
+        mvn -B -f pom.xml sonar:sonar \
+            -Dsonar.host.url=$SONARQUBE_HOST_URL \
+            -Dsonar.login=$SONARQUBE_TOKEN \
+            -Dsonar.branch.name=${GITHUB_REF##*/} \
+            -Dsonar.projectName="$PROJECT_NAME" \
+            -Dsonar.qualitygate.wait=true \
+            $KEY_OPTION
       env:
         SONARQUBE_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
+        SONARQUBE_HOST_URL: ${{ vars.SONARQUBE_HOST_URL }}
         PROJECT_KEY: ${{ github.repository }}
         PROJECT_NAME: 'Hipparchus'
         KEY_OPTION: ''

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
             -Dsonar.login=$SONARQUBE_TOKEN \
             -Dsonar.branch.name=${GITHUB_REF##*/} \
             -Dsonar.projectName="$PROJECT_NAME" \
-            -Dsonar.qualitygate.wait=true \
+              \
             $KEY_OPTION
       env:
         SONARQUBE_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}

--- a/hipparchus-parent/pom.xml
+++ b/hipparchus-parent/pom.xml
@@ -530,8 +530,6 @@
     <hipparchus.hamcrest.version>2.2</hipparchus.hamcrest.version>
     <hipparchus.reflow-velocity-tools.version>2.0.0</hipparchus.reflow-velocity-tools.version>
     <hipparchus.mathjax.enable>&lt;script src=&quot;https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js&quot; id=&quot;MathJax-script&quot;&gt;&lt;/script&gt;</hipparchus.mathjax.enable>
-    <!-- sonar related properties -->
-    <sonar.host.url>https://sonar.orekit.org/</sonar.host.url>
   </properties>
 
   <build>


### PR DESCRIPTION
Following the migration of Orekit's SonarQube instance from version 7.5 to version 9.9 LTS, some adjustments to the Hipparchus CI/CD environment are required.

I took the opportunity to extract the SonarQube server URL from the `pom.xml` file and make it configurable via a Github Actions configuration variable, named `SONARQUBE_HOST_URL`.

I've already made the necessary changes in the Github Actions environment:
* Updating `SONARQUBE_TOKEN`
* Adding `SONARQUBE_HOST_URL` configuration variable