### PR TITLE
CI/CD code enhancement

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
             -Dsonar.login=$SONARQUBE_TOKEN \
             -Dsonar.branch.name=${GITHUB_REF##*/} \
             -Dsonar.projectName="$PROJECT_NAME" \
-              \
+            -Dsonar.qualitygate.wait=true \
             $KEY_OPTION
       env:
         SONARQUBE_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,21 +17,18 @@ jobs:
       run: mvn -B -U -f pom.xml install checkstyle:checkstyle
     - name: SonarQube scan
       run: |
-        if [ $PROJECT_KEY != 'Hipparchus-Math/hipparchus' ] ; then export KEY_OPTION="-Dsonar.projectKey=${PROJECT_KEY/\//:}" ; fi
-        if [ $PROJECT_KEY != 'Hipparchus-Math/hipparchus' ] ; then export PROJECT_NAME="$PROJECT_NAME ($PROJECT_KEY)" ; fi
+        export PROJECT_NAME="Hipparchus ($GITHUB_REPOSITORY)"
+        export PROJECT_KEY=${GITHUB_REPOSITORY/\//:}
         mvn -B -f pom.xml sonar:sonar \
             -Dsonar.host.url=$SONARQUBE_HOST_URL \
             -Dsonar.login=$SONARQUBE_TOKEN \
             -Dsonar.branch.name=${GITHUB_REF##*/} \
             -Dsonar.projectName="$PROJECT_NAME" \
-            -Dsonar.qualitygate.wait=true \
-            $KEY_OPTION
+            -Dsonar.projectKey="$PROJECT_KEY" \
+            -Dsonar.qualitygate.wait=true
       env:
         SONARQUBE_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
         SONARQUBE_HOST_URL: ${{ vars.SONARQUBE_HOST_URL }}
-        PROJECT_KEY: ${{ github.repository }}
-        PROJECT_NAME: 'Hipparchus'
-        KEY_OPTION: ''
     - name: Deployment
       if: ( github.repository == 'Hipparchus-Math/hipparchus' ) && ( ( github.ref == 'refs/heads/master' ) || startsWith( github.ref, 'refs/heads/release-' ) )
       run: mvn -B -U -f pom.xml -s .CI/maven-settings.xml deploy -Pci-deploy -DskipTests=true


### PR DESCRIPTION
I noticed that the Hipparchus CI/CD pipeline code was unnecessarily complicated and did not apply the same naming rules depending on whether the pipeline was running on the original project or on a fork (in the original project, we let Maven choose the key used in SonarQube, whereas for clones, we impose this key according to a strict logic).

This PR aims to simplify and harmonize this code. If you find it acceptable, **please let me know before merging the code**, as I'll need to adjust the Hipparchus project key in SonarQube. Otherwise, the pipeline will fail.
