### PR TITLE
#328: Implemented inverse unscented transform

### DIFF
--- a/hipparchus-core/src/main/java/org/hipparchus/util/AbstractUnscentedTransform.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/util/AbstractUnscentedTransform.java
@@ -19,7 +19,6 @@ package org.hipparchus.util;
 import org.hipparchus.exception.LocalizedCoreFormats;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.linear.ArrayRealVector;
-import org.hipparchus.linear.MatrixUtils;
 import org.hipparchus.linear.RealMatrix;
 import org.hipparchus.linear.RealVector;
 import org.hipparchus.linear.SemiDefinitePositiveCholeskyDecomposition;
@@ -80,43 +79,6 @@ public abstract class AbstractUnscentedTransform implements UnscentedTransformPr
         // Return sigma points
         return sigmaPoints;
 
-    }
-
-    /** {@inheritDoc}. */
-    @Override
-    public Pair<RealVector, RealMatrix> inverseUnscentedTransform(final RealVector[] sigmaPoints) {
-
-        // State dimension
-        final int stateDimension = sigmaPoints[0].getDimension();
-
-        // Compute weighted mean
-        // ---------------------
-
-        RealVector weightedMean = new ArrayRealVector(stateDimension);
-
-        // Compute the weight coefficients wm
-        final RealVector wm = getWm();
-
-        // Weight each sigma point and sum them
-        for (int i = 0; i <= 2 * stateDimension; i++) {
-            weightedMean = weightedMean.add(sigmaPoints[i].mapMultiply(wm.getEntry(i)));
-        }
-
-        // Compute covariance matrix
-        // -------------------------
-
-        RealMatrix covarianceMatrix = MatrixUtils.createRealMatrix(stateDimension, stateDimension);
-
-        // Compute the weight coefficients wc
-        final RealVector wc = getWc();
-
-        // Reconstruct the covariance
-        for (int i = 0; i <= 2 * stateDimension; i++) {
-            final RealMatrix diff = MatrixUtils.createColumnRealMatrix(sigmaPoints[i].subtract(weightedMean).toArray());
-            covarianceMatrix = covarianceMatrix.add(diff.multiplyTransposed(diff).scalarMultiply(wc.getEntry(i)));
-        }
-
-        return new Pair<>(weightedMean, covarianceMatrix);
     }
 
     /**

--- a/hipparchus-core/src/main/java/org/hipparchus/util/AbstractUnscentedTransform.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/util/AbstractUnscentedTransform.java
@@ -19,6 +19,7 @@ package org.hipparchus.util;
 import org.hipparchus.exception.LocalizedCoreFormats;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.linear.ArrayRealVector;
+import org.hipparchus.linear.MatrixUtils;
 import org.hipparchus.linear.RealMatrix;
 import org.hipparchus.linear.RealVector;
 import org.hipparchus.linear.SemiDefinitePositiveCholeskyDecomposition;
@@ -79,6 +80,43 @@ public abstract class AbstractUnscentedTransform implements UnscentedTransformPr
         // Return sigma points
         return sigmaPoints;
 
+    }
+
+    /** {@inheritDoc}. */
+    @Override
+    public Pair<RealVector, RealMatrix> inverseUnscentedTransform(final RealVector[] sigmaPoints) {
+
+        // State dimension
+        final int stateDimension = sigmaPoints[0].getDimension();
+
+        // Compute weighted mean
+        // ---------------------
+
+        RealVector weightedMean = new ArrayRealVector(stateDimension);
+
+        // Compute the weight coefficients wm
+        final RealVector wm = getWm();
+
+        // Weight each sigma point and sum them
+        for (int i = 0; i <= 2 * stateDimension; i++) {
+            weightedMean = weightedMean.add(sigmaPoints[i].mapMultiply(wm.getEntry(i)));
+        }
+
+        // Compute covariance matrix
+        // -------------------------
+
+        RealMatrix covarianceMatrix = MatrixUtils.createRealMatrix(stateDimension, stateDimension);
+
+        // Compute the weight coefficients wc
+        final RealVector wc = getWc();
+
+        // Reconstruct the covariance
+        for (int i = 0; i <= 2 * stateDimension; i++) {
+            final RealMatrix diff = MatrixUtils.createColumnRealMatrix(sigmaPoints[i].subtract(weightedMean).toArray());
+            covarianceMatrix = covarianceMatrix.add(diff.multiplyTransposed(diff).scalarMultiply(wc.getEntry(i)));
+        }
+
+        return new Pair<>(weightedMean, covarianceMatrix);
     }
 
     /**

--- a/hipparchus-core/src/main/java/org/hipparchus/util/UnscentedTransformProvider.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/util/UnscentedTransformProvider.java
@@ -34,6 +34,13 @@ public interface UnscentedTransformProvider {
     RealVector[] unscentedTransform(RealVector state, RealMatrix covariance);
 
     /**
+     * Perform the inverse unscented transform from an array of sigma points.
+     * @param sigmaPoints array containing the sigma points of the unscented transform
+     * @return mean state and associated covariance
+     */
+    Pair<RealVector, RealMatrix> inverseUnscentedTransform(RealVector[] sigmaPoints);
+
+    /**
      * Get the covariance weights.
      * @return the covariance weights
      */

--- a/hipparchus-core/src/test/java/org/hipparchus/util/JulierUnscentedTransformTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/util/JulierUnscentedTransformTest.java
@@ -53,7 +53,7 @@ public class JulierUnscentedTransformTest {
 
     }
 
-    /** test unscented transform */
+    /** Test unscented transform */
     @Test
     public void testUnscentedTransform() {
 
@@ -74,6 +74,36 @@ public class JulierUnscentedTransformTest {
         checkSigmaPoint(sigma[3], 0.0, 1.0);
         checkSigmaPoint(sigma[4], 1.0, 0.0);
 
+    }
+
+    /** Test inverse unscented transform */
+    @Test
+    public void testInverseUnscentedTransform() {
+        
+        // Initialize
+        final int stateDim = 2;
+        final JulierUnscentedTransform julier = new JulierUnscentedTransform(stateDim);
+        final RealVector[] sigmaPoints = new RealVector[] {MatrixUtils.createRealVector(new double[] {1.0, 1.0}),
+                                                           MatrixUtils.createRealVector(new double[] {2.0, 1.0}),
+                                                           MatrixUtils.createRealVector(new double[] {1.0, 2.0}),
+                                                           MatrixUtils.createRealVector(new double[] {0.0, 1.0}),
+                                                           MatrixUtils.createRealVector(new double[] {1.0, 0.0})};
+        // Action
+        final Pair<RealVector, RealMatrix> out = julier.inverseUnscentedTransform(sigmaPoints);
+        final RealVector state = out.getFirst();
+        final RealMatrix covariance = out.getSecond();
+        
+        // Verify
+        Assert.assertEquals(2, state.getDimension());
+        Assert.assertEquals(1.0, state.getEntry(0), 0.);
+        Assert.assertEquals(1.0, state.getEntry(1), 0.);
+        
+        Assert.assertEquals(2, covariance.getColumnDimension());
+        Assert.assertEquals(2, covariance.getRowDimension());
+        Assert.assertEquals(0.5, covariance.getEntry(0, 0), 0.);
+        Assert.assertEquals(0.0, covariance.getEntry(0, 1), 0.);
+        Assert.assertEquals(0.0, covariance.getEntry(1, 0), 0.);
+        Assert.assertEquals(0.5, covariance.getEntry(1, 1), 0.);
     }
 
     private static void checkSigmaPoint(final RealVector sigma, final double ref1, final double ref2) {

--- a/hipparchus-core/src/test/java/org/hipparchus/util/JulierUnscentedTransformTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/util/JulierUnscentedTransformTest.java
@@ -89,9 +89,9 @@ public class JulierUnscentedTransformTest {
                                                            MatrixUtils.createRealVector(new double[] {0.0, 1.0}),
                                                            MatrixUtils.createRealVector(new double[] {1.0, 0.0})};
         // Action
-        final Pair<RealVector, RealMatrix> out = julier.inverseUnscentedTransform(sigmaPoints);
-        final RealVector state = out.getFirst();
-        final RealMatrix covariance = out.getSecond();
+        final Pair<RealVector, RealMatrix> inverse = julier.inverseUnscentedTransform(sigmaPoints);
+        final RealVector state = inverse.getFirst();
+        final RealMatrix covariance = inverse.getSecond();
         
         // Verify
         Assert.assertEquals(2, state.getDimension());

--- a/hipparchus-core/src/test/java/org/hipparchus/util/MerweUnscentedTransformTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/util/MerweUnscentedTransformTest.java
@@ -59,12 +59,12 @@ public class MerweUnscentedTransformTest {
 
         // Initialize
         final int stateDim = 2;
-        final MerweUnscentedTransform julier = new MerweUnscentedTransform(stateDim, 0.5, 2.0, 0.0);
+        final MerweUnscentedTransform merwe = new MerweUnscentedTransform(stateDim, 0.5, 2.0, 0.0);
         final RealVector state = MatrixUtils.createRealVector(new double[] {1.0, 1.0});
         final RealMatrix covariance = MatrixUtils.createRealDiagonalMatrix(new double[] {0.5, 0.5});
 
         // Action
-        final RealVector[] sigma = julier.unscentedTransform(state, covariance);
+        final RealVector[] sigma = merwe.unscentedTransform(state, covariance);
 
         // Verify
         Assert.assertEquals(5, sigma.length);
@@ -73,7 +73,36 @@ public class MerweUnscentedTransformTest {
         checkSigmaPoint(sigma[2], 1.0, 1.5);
         checkSigmaPoint(sigma[3], 0.5, 1.0);
         checkSigmaPoint(sigma[4], 1.0, 0.5);
+    }
 
+    /** Test inverse unscented transform */
+    @Test
+    public void testInverseUnscentedTransform() {
+        
+        // Initialize
+        final int stateDim = 2;
+        final MerweUnscentedTransform merwe = new MerweUnscentedTransform(stateDim, 0.5, 2.0, 0.0);
+        final RealVector[] sigmaPoints = new RealVector[] {MatrixUtils.createRealVector(new double[] {1.0, 1.0}),
+                                                           MatrixUtils.createRealVector(new double[] {1.5, 1.0}),
+                                                           MatrixUtils.createRealVector(new double[] {1.0, 1.5}),
+                                                           MatrixUtils.createRealVector(new double[] {0.5, 1.0}),
+                                                           MatrixUtils.createRealVector(new double[] {1.0, 0.5})};
+        // Action
+        final Pair<RealVector, RealMatrix> out = merwe.inverseUnscentedTransform(sigmaPoints);
+        final RealVector state = out.getFirst();
+        final RealMatrix covariance = out.getSecond();
+        
+        // Verify
+        Assert.assertEquals(2, state.getDimension());
+        Assert.assertEquals(1.0, state.getEntry(0), 0.);
+        Assert.assertEquals(1.0, state.getEntry(1), 0.);
+        
+        Assert.assertEquals(2, covariance.getColumnDimension());
+        Assert.assertEquals(2, covariance.getRowDimension());
+        Assert.assertEquals(0.5, covariance.getEntry(0, 0), 0.);
+        Assert.assertEquals(0.0, covariance.getEntry(0, 1), 0.);
+        Assert.assertEquals(0.0, covariance.getEntry(1, 0), 0.);
+        Assert.assertEquals(0.5, covariance.getEntry(1, 1), 0.);
     }
 
     private static void checkSigmaPoint(final RealVector sigma, final double ref1, final double ref2) {

--- a/hipparchus-core/src/test/java/org/hipparchus/util/MerweUnscentedTransformTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/util/MerweUnscentedTransformTest.java
@@ -74,7 +74,7 @@ public class MerweUnscentedTransformTest {
         checkSigmaPoint(sigma[3], 0.5, 1.0);
         checkSigmaPoint(sigma[4], 1.0, 0.5);
     }
-
+    
     /** Test inverse unscented transform */
     @Test
     public void testInverseUnscentedTransform() {
@@ -88,9 +88,9 @@ public class MerweUnscentedTransformTest {
                                                            MatrixUtils.createRealVector(new double[] {0.5, 1.0}),
                                                            MatrixUtils.createRealVector(new double[] {1.0, 0.5})};
         // Action
-        final Pair<RealVector, RealMatrix> out = merwe.inverseUnscentedTransform(sigmaPoints);
-        final RealVector state = out.getFirst();
-        final RealMatrix covariance = out.getSecond();
+        final Pair<RealVector, RealMatrix> inverse = merwe.inverseUnscentedTransform(sigmaPoints);
+        final RealVector state = inverse.getFirst();
+        final RealMatrix covariance = inverse.getSecond();
         
         // Verify
         Assert.assertEquals(2, state.getDimension());

--- a/hipparchus-filtering/src/test/java/org/hipparchus/filtering/kalman/unscented/UnscentedKalmanFilterTest.java
+++ b/hipparchus-filtering/src/test/java/org/hipparchus/filtering/kalman/unscented/UnscentedKalmanFilterTest.java
@@ -30,11 +30,17 @@ import org.hipparchus.filtering.kalman.SimpleMeasurement;
 import org.hipparchus.filtering.kalman.extended.ExtendedKalmanFilter;
 import org.hipparchus.filtering.kalman.extended.NonLinearEvolution;
 import org.hipparchus.filtering.kalman.extended.NonLinearProcess;
-import org.hipparchus.linear.*;
+import org.hipparchus.linear.ArrayRealVector;
+import org.hipparchus.linear.CholeskyDecomposer;
+import org.hipparchus.linear.MatrixUtils;
+import org.hipparchus.linear.QRDecomposer;
+import org.hipparchus.linear.RealMatrix;
+import org.hipparchus.linear.RealVector;
 import org.hipparchus.random.RandomGenerator;
 import org.hipparchus.random.Well1024a;
 import org.hipparchus.util.FastMath;
 import org.hipparchus.util.MerweUnscentedTransform;
+import org.hipparchus.util.Pair;
 import org.hipparchus.util.UnscentedTransformProvider;
 import org.junit.Assert;
 import org.junit.Test;
@@ -65,6 +71,14 @@ public class UnscentedKalmanFilterTest {
             @Override
             public RealVector getWc() {
                 return new ArrayRealVector();
+            }
+
+            @Override
+            public Pair<RealVector, RealMatrix> inverseUnscentedTransform(RealVector[] sigmaPoints) {
+                
+                final int stateDimension = sigmaPoints[0].getDimension();
+                
+                return new Pair<>(sigmaPoints[0], MatrixUtils.createRealIdentityMatrix(stateDimension));
             }
         };
 

--- a/hipparchus-filtering/src/test/java/org/hipparchus/filtering/kalman/unscented/UnscentedKalmanFilterTest.java
+++ b/hipparchus-filtering/src/test/java/org/hipparchus/filtering/kalman/unscented/UnscentedKalmanFilterTest.java
@@ -40,7 +40,6 @@ import org.hipparchus.random.RandomGenerator;
 import org.hipparchus.random.Well1024a;
 import org.hipparchus.util.FastMath;
 import org.hipparchus.util.MerweUnscentedTransform;
-import org.hipparchus.util.Pair;
 import org.hipparchus.util.UnscentedTransformProvider;
 import org.junit.Assert;
 import org.junit.Test;
@@ -71,14 +70,6 @@ public class UnscentedKalmanFilterTest {
             @Override
             public RealVector getWc() {
                 return new ArrayRealVector();
-            }
-
-            @Override
-            public Pair<RealVector, RealMatrix> inverseUnscentedTransform(RealVector[] sigmaPoints) {
-                
-                final int stateDimension = sigmaPoints[0].getDimension();
-                
-                return new Pair<>(sigmaPoints[0], MatrixUtils.createRealIdentityMatrix(stateDimension));
             }
         };
 


### PR DESCRIPTION
This is a tentative proposal for fixing #328.  

I made it so that this is minor-version-compatible since I put all the code in default methods of the interface `UnscentedTrasnformProvider`.

I used this occasion to refactor some common code with the `UnscentedKalmanFilter`.