### PR TITLE
Fixed issue 347: JUnit pioneer dependency version not compatible with Java 8

### DIFF
--- a/hipparchus-parent/pom.xml
+++ b/hipparchus-parent/pom.xml
@@ -567,7 +567,7 @@
     <hipparchus.maven-install-plugin.version>3.1.1</hipparchus.maven-install-plugin.version>
     <hipparchus.apache-rat-plugin.version>0.16.1</hipparchus.apache-rat-plugin.version>
     <hipparchus.junit.version>5.10.3</hipparchus.junit.version>
-    <hipparchus.junit.pioneer.version>2.2.0</hipparchus.junit.pioneer.version>
+    <hipparchus.junit.pioneer.version>1.9.1</hipparchus.junit.pioneer.version>
     <hipparchus.mockito-core.version>5.12.0</hipparchus.mockito-core.version>
     <hipparchus.hamcrest.version>2.2</hipparchus.hamcrest.version>
     <hipparchus.reflow-velocity-tools.version>2.0.0</hipparchus.reflow-velocity-tools.version>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -50,8 +50,11 @@ If the output is not quite correct, check for invisible trailing spaces!
   </properties>
   <body>
     <release version="3.2" date="TBD" description="TBD">
+      <action dev="vincent" type="fix" issue="issues/347">
+        Fixed JUnit pioneer dependency version not compatible with Java 8.
+      </action>
       <action dev="vincent" type="update" issue="issues/285">
-        Migrated tests from JUnit 4 to JUnit 5
+        Migrated tests from JUnit 4 to JUnit 5.
       </action>
       <action dev="luc" type="fix" issue="issues/339">
         Changed CDN for faster site load.


### PR DESCRIPTION
Closes #347 