### PR TITLE
Issue 353: Split getEvolution in UnscentedProcess

### DIFF
--- a/hipparchus-filtering/src/main/java/org/hipparchus/filtering/kalman/unscented/UnscentedEvolution.java
+++ b/hipparchus-filtering/src/main/java/org/hipparchus/filtering/kalman/unscented/UnscentedEvolution.java
@@ -32,20 +32,14 @@ public class UnscentedEvolution {
     /** State vectors at current time. */
     private final RealVector[] currentStates;
 
-    /** Process noise matrix. */
-    private final RealMatrix processNoiseMatrix;
-
     /**
      * Constructor.
      * @param currentTime current time
      * @param currentStates state vectors at current time
-     * @param processNoiseMatrix process noise matrix
      */
-    public UnscentedEvolution(final double currentTime, final RealVector[] currentStates,
-                              final RealMatrix processNoiseMatrix) {
+    public UnscentedEvolution(final double currentTime, final RealVector[] currentStates) {
         this.currentTime         = currentTime;
         this.currentStates       = currentStates.clone();
-        this.processNoiseMatrix  = processNoiseMatrix;
     }
 
     /** Get current time.
@@ -60,13 +54,6 @@ public class UnscentedEvolution {
      */
     public RealVector[] getCurrentStates() {
         return currentStates.clone();
-    }
-
-    /** Get process noise.
-     * @return process noise
-     */
-    public RealMatrix getProcessNoiseMatrix() {
-        return processNoiseMatrix;
     }
 
 }

--- a/hipparchus-filtering/src/main/java/org/hipparchus/filtering/kalman/unscented/UnscentedProcess.java
+++ b/hipparchus-filtering/src/main/java/org/hipparchus/filtering/kalman/unscented/UnscentedProcess.java
@@ -41,6 +41,14 @@ public interface UnscentedProcess<T extends Measurement>  {
      */
     UnscentedEvolution getEvolution(double previousTime, RealVector[] sigmaPoints, T measurement);
 
+    /** Get the process noise covariance corresponding to the state evolution between two times.
+     * @param previousTime time of the previous state
+     * @param predictedState predicted state
+     * @param measurement measurement to process
+     * @return states evolution
+     */
+    RealMatrix getProcessNoiseMatrix(double previousTime, RealVector predictedState, T measurement);
+
     /** Get the state evolution between two times.
      * @param predictedSigmaPoints predicted state sigma points
      * @param measurement measurement to process


### PR DESCRIPTION
Separate the process noise calculation from the state evolution (prediction) in the unscented filter.
This addresses issue #353.