### PR TITLE
FastMath Reduction

### DIFF
--- a/hipparchus-core/src/changes/changes.xml
+++ b/hipparchus-core/src/changes/changes.xml
@@ -49,6 +49,13 @@ If the output is not quite correct, check for invisible trailing spaces!
     <title>Hipparchus Core Release Notes</title>
   </properties>
   <body>
+    <release version="TBD" date="TBD" description="TBD">
+      <action dev="ryan" type="update" issue="issues/391">
+        Replaced custom FastMath implementations of
+          sin, cos, tan, sinCos, log1p, log10, log, exp, hypot, cbrt, pow, floor, ceil, and abs
+        with delegates to Math
+      </action>
+    </release>
     <release version="4.1" date="TBD" description="TBD">
       <action dev="luc" type="fix" issue="issues/394">
         Prevent stack overflow in digamma function.

--- a/hipparchus-core/src/main/java/org/hipparchus/util/FastMath.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/util/FastMath.java
@@ -897,21 +897,10 @@ public class FastMath {
     }
 
     /**
-     * Exponential function.
-     *
-     * Computes exp(x), function result is nearly rounded.   It will be correctly
-     * rounded to the theoretical value for 99.9% of input values, otherwise it will
-     * have a 1 ULP error.
-     *
-     * Method:
-     *    Lookup intVal = exp(int(x))
-     *    Lookup fracVal = exp(int(x-int(x) / 1024.0) * 1024.0 );
-     *    Compute z as the exponential of the remaining bits by a polynomial minus one
-     *    exp(x) = intVal * fracVal * (1 + z)
-     *
-     * Accuracy:
-     *    Calculation is done with 63 bits of precision, so result should be correctly
-     *    rounded for 99.9% of input values, with less than 1 ULP error otherwise.
+     * Exponential function.<br>
+     * <br>
+     * 
+     * Delegates to {@link Math#exp(double)}
      *
      * @param x   a double
      * @return double e<sup>x</sup>
@@ -1215,7 +1204,10 @@ public class FastMath {
     }
 
     /**
-     * Natural logarithm.
+     * Natural logarithm.<br>
+     * <br>
+     * 
+     * Delegates to {@link Math#log(double)}
      *
      * @param x   a double
      * @return log(x)
@@ -1225,7 +1217,10 @@ public class FastMath {
     }
 
     /**
-     * Computes log(1 + x).
+     * Computes log(1 + x).<br>
+     * <br>
+     * 
+     * Delegates to {@link Math#log1p(double)}
      *
      * @param x Number.
      * @return {@code log(1 + x)}.
@@ -1234,7 +1229,11 @@ public class FastMath {
         return Math.log1p(x);
     }
 
-    /** Compute the base 10 logarithm.
+    /** Compute the base 10 logarithm.<br>
+     * <br>
+     * 
+     * Delegates to {@link Math#log10(double)}
+     * 
      * @param x a number
      * @return log10(x)
      */
@@ -1262,7 +1261,10 @@ public class FastMath {
     }
 
     /**
-     * Power function.  Compute x^y.
+     * Power function.  Compute x^y.<br>
+     * <br>
+     * 
+     * Delegates to {@link Math#pow(double, double)}
      *
      * @param x   a double
      * @param y   a double
@@ -1426,7 +1428,10 @@ public class FastMath {
     }
 
     /**
-     * Sine function.
+     * Sine function.<br>
+     * <br>
+     * 
+     * Delegates to {@link Math#sin(double)}
      *
      * @param x Argument.
      * @return sin(x)
@@ -1436,7 +1441,10 @@ public class FastMath {
     }
 
     /**
-     * Cosine function.
+     * Cosine function.<br>
+     * <br>
+     * 
+     * Delegates to {@link Math#cos(double)}
      *
      * @param x Argument.
      * @return cos(x)
@@ -1446,7 +1454,10 @@ public class FastMath {
     }
 
     /**
-     * Combined Sine and Cosine function.
+     * Combined Sine and Cosine function.<br>
+     * <br>
+     * 
+     * Delegates to {@link Math#sin(double)} and {@link Math#cos(double)}
      *
      * @param x Argument.
      * @return [sin(x), cos(x)]
@@ -1896,7 +1907,11 @@ public class FastMath {
       return atan(ra, rb, x<0);
     }
 
-    /** Compute the cubic root of a number.
+    /** Compute the cubic root of a number.<br>
+     * <br>
+     * 
+     * Delegates to {@link Math#cbrt(double)}
+     * 
      * @param x number on which evaluation is done
      * @return cubic root of x
      */
@@ -2011,7 +2026,11 @@ public class FastMath {
     }
 
     /**
-     * Absolute value.
+     * Absolute value.<br>
+     * <br>
+     * 
+     * Delegates to {@link Math#abs(double)}
+     * 
      * @param x number from which absolute value is requested
      * @return abs(x)
      */
@@ -2355,7 +2374,11 @@ public class FastMath {
 
     }
 
-    /** Get the largest whole number smaller than x.
+    /** Get the largest whole number smaller than x.<br>
+     * <br>
+     * 
+     * Delegates to {@link Math#floor(double)}
+     * 
      * @param x number from which floor is requested
      * @return a double number f such that f is an integer f &lt;= x &lt; f + 1.0
      */
@@ -2363,7 +2386,11 @@ public class FastMath {
         return Math.floor(x);
     }
 
-    /** Get the smallest whole number larger than x.
+    /** Get the smallest whole number larger than x.<br>
+     * <br>
+     * 
+     * Delegates to {@link Math#ceil(double)}
+     * 
      * @param x number from which ceil is requested
      * @return a double number c such that c is an integer c - 1.0 &lt; x &lt;= c
      */
@@ -2591,7 +2618,9 @@ public class FastMath {
      * <li> If either argument is infinite, then the result is positive infinity.</li>
      * <li> else, if either argument is NaN then the result is NaN.</li>
      * </ul>
-     *
+     * 
+     * Delegates to {@link Math#hypot(double, double)}
+     * 
      * @param x a value
      * @param y a value
      * @return sqrt(<i>x</i><sup>2</sup>&nbsp;+<i>y</i><sup>2</sup>)

--- a/hipparchus-core/src/test/java/org/hipparchus/analysis/differentiation/DerivativeStructureTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/analysis/differentiation/DerivativeStructureTest.java
@@ -951,7 +951,7 @@ public class DerivativeStructureTest extends CalculusFieldElementAbstractTest<De
 
     @Test
     void testLog1pExpm1() {
-        double[] epsilon = new double[] { 6.0e-17, 3.0e-16, 5.0e-16, 9.0e-16, 6.0e-15 };
+        double[] epsilon = new double[] { 1.2e-16, 3.0e-16, 5.0e-16, 9.0e-16, 6.0e-15 };
         for (int maxOrder = 0; maxOrder < 5; ++maxOrder) {
             DSFactory factory = new DSFactory(1, maxOrder);
             for (double x = 0.1; x < 1.2; x += 0.001) {

--- a/hipparchus-core/src/test/java/org/hipparchus/analysis/differentiation/FieldDerivativeStructureAbstractTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/analysis/differentiation/FieldDerivativeStructureAbstractTest.java
@@ -942,7 +942,7 @@ public abstract class FieldDerivativeStructureAbstractTest<T extends CalculusFie
     @Override
     @Test
     public void testExp() {
-        double[] epsilon = new double[] { 1.0e-16, 1.0e-16, 1.0e-16, 1.0e-16, 1.0e-16 };
+        double[] epsilon = new double[] { 5.0e-16, 5.0e-16, 5.0e-16, 5.0e-16, 5.0e-16 };
         for (int maxOrder = 0; maxOrder < 5; ++maxOrder) {
             final FDSFactory<T> factory = buildFactory(1, maxOrder);
             for (double x = 0.1; x < 1.2; x += 0.001) {

--- a/hipparchus-core/src/test/java/org/hipparchus/analysis/differentiation/FiniteDifferencesDifferentiatorTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/analysis/differentiation/FiniteDifferencesDifferentiatorTest.java
@@ -116,7 +116,7 @@ class FiniteDifferencesDifferentiatorTest {
         UnivariateDifferentiableFunction f =
                 differentiator.differentiate(gaussian);
         double[] expectedError = new double[] {
-            6.939e-18, 1.284e-15, 2.477e-13, 1.168e-11, 2.840e-9, 7.971e-8
+            6.939e-18, 1.284e-15, 2.385e-13, 1.168e-11, 2.668e-9, 7.971e-8
         };
         double[] maxError = new double[expectedError.length];
         DSFactory factory = new DSFactory(1, maxError.length - 1);

--- a/hipparchus-core/src/test/java/org/hipparchus/distribution/continuous/GammaDistributionTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/distribution/continuous/GammaDistributionTest.java
@@ -360,6 +360,6 @@ public class GammaDistributionTest extends RealDistributionAbstractTest {
 
     @Test
     void testMath753Shape1000() throws IOException {
-        doTestMath753(1000.0, 1.0, 1.0, 160.0, 220.0, "gamma-distribution-shape-1000.csv");
+        doTestMath753(1000.0, 1.0, 1.0, 158.0, 230.0, "gamma-distribution-shape-1000.csv");
     }
 }

--- a/hipparchus-core/src/test/java/org/hipparchus/util/FastMathCalcTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/util/FastMathCalcTest.java
@@ -93,23 +93,6 @@ class FastMathCalcTest {
     }
 
     @Test
-    void testLnMantTables() {
-        final double[][] fmTable  = getD2("lnMant", "LN_MANT");
-        final int      len        = getInt("LN_MANT_LEN");
-        assertEquals(len, fmTable.length);
-
-        for (int i = 0; i < len; i++) {
-            final double d = Double.longBitsToDouble( (((long) i) << 42) | 0x3ff0000000000000L );
-            final double[] tmp = FastMathCalc.slowLog(d);
-            assertEquals(fmTable[i].length, tmp.length);
-            for (int j = 0; j < fmTable[i].length; ++j) {
-                assertEquals(fmTable[i][j], tmp[j], FastMath.ulp(fmTable[i][j]));
-            }
-        }
-
-    }
-
-    @Test
     void testSplit() {
         checkSplit(0x3ffe0045dab7321fl, 0x3ffe0045c0000000l, 0x3e7ab7321f000000l);
         checkSplit(0x3ffe0045fab7321fl, 0x3ffe004600000000l, 0xbe55233784000000l);
@@ -129,40 +112,6 @@ class FastMathCalcTest {
             assertEquals(bits, Double.doubleToRawLongBits(result[0] + result[1]));
             assertEquals(high, Double.doubleToRawLongBits(result[0]));
             assertEquals(low,  Double.doubleToRawLongBits(result[1]));
-
-        } catch (NoSuchMethodException | SecurityException | IllegalArgumentException |
-                 IllegalAccessException | InvocationTargetException e) {
-            fail(e.getLocalizedMessage());
-        }
-    }
-
-    @Test
-    void testSinCosTanTables() {
-        try {
-            final double[] sinA = getFastMathTable("SINE_TABLE_A");
-            final double[] sinB = getFastMathTable("SINE_TABLE_B");
-            final double[] cosA = getFastMathTable("COSINE_TABLE_A");
-            final double[] cosB = getFastMathTable("COSINE_TABLE_B");
-            final double[] tanA = getFastMathTable("TANGENT_TABLE_A");
-            final double[] tanB = getFastMathTable("TANGENT_TABLE_B");
-            Method buildSinCosTables = FastMathCalc.class.getDeclaredMethod("buildSinCosTables",
-                                                                            double[].class, double[].class, double[].class, double[].class,
-                                                                            Integer.TYPE,
-                                                                            double[].class, double[].class);
-            buildSinCosTables.setAccessible(true);
-            final double[] calcSinA = new double[sinA.length];
-            final double[] calcSinB = new double[sinB.length];
-            final double[] calcCosA = new double[cosA.length];
-            final double[] calcCosB = new double[cosB.length];
-            final double[] calcTanA = new double[tanA.length];
-            final double[] calcTanB = new double[tanB.length];
-            buildSinCosTables.invoke(null, calcSinA, calcSinB, calcCosA, calcCosB, sinA.length, calcTanA, calcTanB);
-            checkTable(sinA, calcSinA, 0);
-            checkTable(sinB, calcSinB, 0);
-            checkTable(cosA, calcCosA, 0);
-            checkTable(cosB, calcCosB, 0);
-            checkTable(tanA, calcTanA, 0);
-            checkTable(tanB, calcTanB, 0);
 
         } catch (NoSuchMethodException | SecurityException | IllegalArgumentException |
                  IllegalAccessException | InvocationTargetException e) {

--- a/hipparchus-ode/src/test/java/org/hipparchus/ode/VariationalEquationTest.java
+++ b/hipparchus-ode/src/test/java/org/hipparchus/ode/VariationalEquationTest.java
@@ -92,8 +92,8 @@ class VariationalEquationTest {
         assertTrue(residualsP0.getStandardDeviation() < 0.004);
         assertTrue((residualsP1.getMax() - residualsP1.getMin()) > 0.04);
         assertTrue((residualsP1.getMax() - residualsP1.getMin()) < 0.05);
-        assertTrue(residualsP1.getStandardDeviation() > 0.007);
-        assertTrue(residualsP1.getStandardDeviation() < 0.008);
+        assertTrue(residualsP1.getStandardDeviation() > 0.0069);
+        assertTrue(residualsP1.getStandardDeviation() < 0.007);
     }
 
     @Test

--- a/hipparchus-parent/pom.xml
+++ b/hipparchus-parent/pom.xml
@@ -265,6 +265,9 @@
       <name>Patrick Meyer</name>
     </contributor>
     <contributor>
+      <name>Ryan Moser</name>
+    </contributor>
+    <contributor>
       <name>J. Lewis Muir</name>
     </contributor>
     <contributor>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -49,6 +49,13 @@ If the output is not quite correct, check for invisible trailing spaces!
     <title>Hipparchus Release Notes</title>
   </properties>
   <body>
+    <release version="TBD" date="TBD" description="TBD">
+      <action dev="ryan" type="update" issue="issues/391">
+        Replaced custom FastMath implementations of
+          sin, cos, tan, sinCos, log1p, log10, log, exp, hypot, cbrt, pow, floor, ceil, and abs
+        with delegates to Math
+      </action>
+    </release>
     <release version="4.1" date="TBD" description="TBD">
       <action dev="luc" type="fix" issue="issues/394">
         Prevent stack overflow in digamma function.


### PR DESCRIPTION
Closes #391

Replaced custom implementations of `sin`, `cos`, `tan`, `sinCos`, `log1p`, `log10`, `log`, `exp`, `hypot`, `cbrt`, `pow`, `floor`, `ceil`, and `abs` with delegates to `Math`