### PR TITLE
Fixed Issue #392 ResourceBundle.Control not supported in named modules

### DIFF
--- a/hipparchus-core/src/changes/changes.xml
+++ b/hipparchus-core/src/changes/changes.xml
@@ -49,6 +49,9 @@ If the output is not quite correct, check for invisible trailing spaces!
     <title>Hipparchus Core Release Notes</title>
   </properties>
   <body>
+    <action dev="emeric" type="fix" issue="issues/392">
+      Fixed default Localizable.getLocalizedString when running on module path.
+    </action>
     <release version="4.0.1" date="2025-03-21" description="This is a patch release.">
       <action dev="luc" type="fix" issue="issues/386">
         Restores a Java 8 compatible mockito version, which is used only for tests purposes;

--- a/hipparchus-core/src/main/java/org/hipparchus/exception/Localizable.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/exception/Localizable.java
@@ -59,7 +59,16 @@ public interface Localizable extends Serializable {
     default String getLocalizedString(final String baseName, final String key, final Locale locale) {
 
         try {
-            final ResourceBundle bundle = ResourceBundle.getBundle(baseName, locale, new UTF8Control());
+            ResourceBundle bundle;
+            try {
+                bundle = ResourceBundle.getBundle(baseName, locale, new UTF8Control());
+            }
+            catch (UnsupportedOperationException uoe) {
+                // fix for Java 9+ on module path
+                // (see issue https://github.com/Hipparchus-Math/hipparchus/issues/392)
+                bundle = ResourceBundle.getBundle(baseName, locale);
+            }
+
             if (bundle.getLocale().getLanguage().equals(locale.getLanguage()))
             {
                 final String translated = bundle.getString(key);


### PR DESCRIPTION
Add fallback for ResourceBundle.getBundle when application is running on module path.
Fixes  #392 