### PR TITLE
Fixed junit dependency

### DIFF
--- a/hipparchus-parent/pom.xml
+++ b/hipparchus-parent/pom.xml
@@ -493,8 +493,8 @@
       </dependency>
 
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
         <version>${hipparchus.junit.version}</version>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
The dependency `junit:junit:5.11.4` does not exist (https://mvnrepository.com/artifact/junit/junit).

