### PR TITLE
fix(core): improve belonging of point to interval

### DIFF
--- a/hipparchus-core/src/changes/changes.xml
+++ b/hipparchus-core/src/changes/changes.xml
@@ -50,6 +50,9 @@ If the output is not quite correct, check for invisible trailing spaces!
   </properties>
   <body>
     <release version="4.1" date="TBD" description="TBD">
+      <action dev="Marthym" type="update" issue="issues/460">
+        Allow small numerical tolerance in SmoothStepFactory.checkBetweenZeroAndOneIncluded
+      </action>
       <action dev="serrof" type="update">
         Add some FunctionalInterface tag.
       </action>

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/polynomials/SmoothStepFactory.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/polynomials/SmoothStepFactory.java
@@ -30,6 +30,7 @@ import org.hipparchus.util.MathArrays;
  * <a href="https://en.wikipedia.org/wiki/Smoothstep">here</a>.
  */
 public class SmoothStepFactory {
+    private static final double EPSILON = 1E-10;
 
     /**
      * Private constructor.
@@ -209,8 +210,8 @@ public class SmoothStepFactory {
      * @throws MathIllegalArgumentException if input is not between [0:1]
      */
     public static void checkBetweenZeroAndOneIncluded(final double input) throws MathIllegalArgumentException {
-        if (input < 0 - 1E-10 || input > 1 + 1E-10) {
-	    throw new MathIllegalArgumentException(
+        if (input < 0 - EPSILON || input > 1 + EPSILON) {
+            throw new MathIllegalArgumentException(
                     LocalizedCoreFormats.INPUT_EXPECTED_BETWEEN_ZERO_AND_ONE_INCLUDED, input);
         }
     }

--- a/hipparchus-core/src/main/java/org/hipparchus/analysis/polynomials/SmoothStepFactory.java
+++ b/hipparchus-core/src/main/java/org/hipparchus/analysis/polynomials/SmoothStepFactory.java
@@ -209,9 +209,9 @@ public class SmoothStepFactory {
      * @throws MathIllegalArgumentException if input is not between [0:1]
      */
     public static void checkBetweenZeroAndOneIncluded(final double input) throws MathIllegalArgumentException {
-        if (input < 0 || input > 1) {
-            throw new MathIllegalArgumentException(
-                    LocalizedCoreFormats.INPUT_EXPECTED_BETWEEN_ZERO_AND_ONE_INCLUDED);
+        if (input < 0 - 1E-10 || input > 1 + 1E-10) {
+	    throw new MathIllegalArgumentException(
+                    LocalizedCoreFormats.INPUT_EXPECTED_BETWEEN_ZERO_AND_ONE_INCLUDED, input);
         }
     }
 

--- a/hipparchus-core/src/test/java/org/hipparchus/analysis/polynomials/SmoothStepFactoryTest.java
+++ b/hipparchus-core/src/test/java/org/hipparchus/analysis/polynomials/SmoothStepFactoryTest.java
@@ -22,6 +22,7 @@ import org.hipparchus.util.Binary64;
 import org.hipparchus.util.Binary64Field;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -351,4 +352,26 @@ class SmoothStepFactoryTest {
         assertEquals(computedResult2.getReal(), computedResult3.getReal(), THRESHOLD);
     }
 
+    @Test
+    void testBetweenZeroAndOneIncluded() {
+        final double EPSILON = 1E-10;
+        final SmoothStepFactory.SmoothStepFunction cubic = SmoothStepFactory.getCubic();
+
+        // Values strictly within [0, 1] must not raise an exception
+        assertDoesNotThrow(() -> cubic.value(0.0));
+        assertDoesNotThrow(() -> cubic.value(0.5));
+        assertDoesNotThrow(() -> cubic.value(1.0));
+
+        // Values within the epsilon tolerance must not raise an exception
+        assertDoesNotThrow(() -> cubic.value(0.0 - EPSILON / 2));
+        assertDoesNotThrow(() -> cubic.value(1.0 + EPSILON / 2));
+
+        // Values exactly at the epsilon threshold must not throw an exception
+        assertDoesNotThrow(() -> cubic.value(0.0 - EPSILON));
+        assertDoesNotThrow(() -> cubic.value(1.0 + EPSILON));
+
+        // Values exceeding the epsilon tolerance must throw an exception
+        assertThrows(MathIllegalArgumentException.class, () -> cubic.value(0.0 - EPSILON * 2));
+        assertThrows(MathIllegalArgumentException.class, () -> cubic.value(1.0 + EPSILON * 2));
+    }
 }

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -50,6 +50,9 @@ If the output is not quite correct, check for invisible trailing spaces!
   </properties>
   <body>
     <release version="4.1" date="TBD" description="TBD">
+      <action dev="Marthym" type="update" issue="issues/460">
+        Allow small numerical tolerance in SmoothStepFactory.checkBetweenZeroAndOneIncluded
+      </action>
       <action dev="serrof" type="update">
         Add some FunctionalInterface tag.
       </action>


### PR DESCRIPTION
The test to determine whether a point belongs to the interval [0,1] is not robust to numerical errors. However, it is necessary to allow points that are slightly outside the bounds. Tests have shown that a numerical error of up to 1e-10 can occur in some cases.

ref #460 